### PR TITLE
feat: extend employer flows across API and portal

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -8,18 +8,18 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     app_env: str = "development"
-    database_url: str
-    redis_url: str
-    minio_endpoint: str
-    minio_access_key: str
-    minio_secret_key: str
-    meilisearch_url: str
-    meilisearch_api_key: str
-    qdrant_url: str
-    keycloak_url: str
-    keycloak_realm: str
-    keycloak_client_id: str
-    keycloak_client_secret: str
+    database_url: str = "sqlite:///./autohire.db"
+    redis_url: str = "redis://localhost:6379/0"
+    minio_endpoint: str = "http://localhost:9000"
+    minio_access_key: str = "minio"
+    minio_secret_key: str = "minio-secret"
+    meilisearch_url: str = "http://localhost:7700"
+    meilisearch_api_key: str = "test-key"
+    qdrant_url: str = "http://localhost:6333"
+    keycloak_url: str = "http://localhost:8080"
+    keycloak_realm: str = "autohire"
+    keycloak_client_id: str = "autohire-api"
+    keycloak_client_secret: str = "dev-secret"
     posthog_api_key: str | None = None
     allowed_origins: List[str] = []
 

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,0 +1,688 @@
+"""Domain models and in-memory fixtures for the AutoHire API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class EmployerRole(str, Enum):
+    """Role assignments available to employer members."""
+
+    OWNER = "owner"
+    RECRUITER = "recruiter"
+    HIRING_MANAGER = "hiring_manager"
+    CONTRIBUTOR = "contributor"
+
+
+class EmployerMember(BaseModel):
+    """Representation of a user that belongs to an employer organization."""
+
+    user_id: str = Field(..., description="Unique identifier for the user within AutoHire.")
+    email: EmailStr = Field(..., description="Work email for the employer member.")
+    name: str = Field(..., description="Full name of the member.")
+    roles: List[EmployerRole] = Field(default_factory=list, description="Roles granted within the employer.")
+    teams: List[str] = Field(default_factory=list, description="IDs of teams the member participates in.")
+
+
+class Employer(BaseModel):
+    """Top-level organization that owns teams, jobs, and workflows."""
+
+    id: str
+    name: str
+    domain: str
+    description: Optional[str] = None
+    members: List[EmployerMember] = Field(default_factory=list)
+
+
+class Team(BaseModel):
+    """Functional team within an employer."""
+
+    id: str
+    employer_id: str
+    name: str
+    description: Optional[str] = None
+    leads: List[str] = Field(default_factory=list, description="User IDs for the team leads.")
+
+
+class JobStatus(str, Enum):
+    """Lifecycle states for a job opening."""
+
+    OPEN = "open"
+    ON_HOLD = "on_hold"
+    CLOSED = "closed"
+
+
+class PipelineStage(BaseModel):
+    """A single step in a job pipeline."""
+
+    id: str
+    name: str
+    order: int
+    description: Optional[str] = None
+    exit_criteria: Optional[str] = None
+
+
+class JobPipeline(BaseModel):
+    """Workflow definition that candidates move through for a job."""
+
+    id: str
+    employer_id: str
+    job_id: str
+    stages: List[PipelineStage] = Field(default_factory=list)
+
+
+class Job(BaseModel):
+    """Job opening posted by an employer."""
+
+    id: str
+    employer_id: str
+    team_id: str
+    title: str
+    description: Optional[str] = None
+    status: JobStatus = JobStatus.OPEN
+    openings: int = Field(default=1, ge=1)
+    location: str
+    created_at: datetime
+    pipeline_id: str
+    hiring_manager_id: Optional[str] = None
+
+
+class ApplicationStatus(str, Enum):
+    """Possible states for an application."""
+
+    NEW = "new"
+    SCREENING = "screening"
+    INTERVIEW = "interview"
+    OFFER = "offer"
+    HIRED = "hired"
+    REJECTED = "rejected"
+
+
+class Application(BaseModel):
+    """Candidate submission for a particular job."""
+
+    id: str
+    employer_id: str
+    job_id: str
+    candidate_name: str
+    candidate_email: EmailStr
+    status: ApplicationStatus
+    stage_id: str
+    submitted_at: datetime
+    resume_url: Optional[str] = None
+    overall_score: Optional[float] = None
+
+
+class MicrotaskType(str, Enum):
+    """Types of microtasks available."""
+
+    RESUME_REVIEW = "resume_review"
+    STRUCTURED_INTERVIEW = "structured_interview"
+    SKILL_VALIDATION = "skill_validation"
+    DATA_ENRICHMENT = "data_enrichment"
+
+
+class MicrotaskStatus(str, Enum):
+    """Current status of a microtask."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class Microtask(BaseModel):
+    """Discrete task executed by marketplace workers."""
+
+    id: str
+    employer_id: str
+    campaign_id: str
+    title: str
+    type: MicrotaskType
+    status: MicrotaskStatus
+    instructions: str
+    assignee: Optional[str] = None
+    related_application_id: Optional[str] = None
+    stage_id: Optional[str] = None
+    due_at: Optional[datetime] = None
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class CampaignStatus(str, Enum):
+    """Lifecycle of a microtask campaign."""
+
+    DRAFT = "draft"
+    ACTIVE = "active"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+
+
+class MicrotaskCampaign(BaseModel):
+    """Grouping of microtasks launched for a hiring initiative."""
+
+    id: str
+    employer_id: str
+    job_id: Optional[str] = None
+    name: str
+    description: str
+    status: CampaignStatus
+    launch_date: Optional[datetime] = None
+    target_stage_id: Optional[str] = None
+    tasks: List[Microtask] = Field(default_factory=list)
+
+
+class JobCreateRequest(BaseModel):
+    """Payload used when creating a new job posting."""
+
+    title: str
+    team_id: str
+    location: str
+    openings: int = Field(default=1, ge=1)
+    description: Optional[str] = None
+
+
+@dataclass
+class EmployerContext:
+    """Context helper returned from authorization checks."""
+
+    employer: Employer
+    member: EmployerMember
+
+
+# ---------------------------------------------------------------------------
+# In-memory fixtures
+# ---------------------------------------------------------------------------
+
+_EMPLOYERS: Dict[str, Employer] = {
+    "emp-1": Employer(
+        id="emp-1",
+        name="Acme Robotics",
+        domain="acmerobotics.com",
+        description=(
+            "Industrial robotics manufacturer building autonomous assembly systems for "
+            "advanced factories."
+        ),
+        members=[
+            EmployerMember(
+                user_id="user-1",
+                email="alicia.chen@acmerobotics.com",
+                name="Alicia Chen",
+                roles=[EmployerRole.OWNER, EmployerRole.RECRUITER],
+                teams=["team-talent", "team-engineering"],
+            ),
+            EmployerMember(
+                user_id="user-2",
+                email="marcus.reed@acmerobotics.com",
+                name="Marcus Reed",
+                roles=[EmployerRole.RECRUITER],
+                teams=["team-talent"],
+            ),
+            EmployerMember(
+                user_id="user-3",
+                email="priya.natarajan@acmerobotics.com",
+                name="Priya Natarajan",
+                roles=[EmployerRole.HIRING_MANAGER],
+                teams=["team-engineering"],
+            ),
+            EmployerMember(
+                user_id="user-4",
+                email="diego.alvarez@acmerobotics.com",
+                name="Diego Alvarez",
+                roles=[EmployerRole.CONTRIBUTOR],
+                teams=["team-operations"],
+            ),
+        ],
+    )
+}
+
+_TEAMS: List[Team] = [
+    Team(
+        id="team-talent",
+        employer_id="emp-1",
+        name="Talent Acquisition",
+        description="Central recruiting operations coordinating hiring activities.",
+        leads=["user-1"],
+    ),
+    Team(
+        id="team-engineering",
+        employer_id="emp-1",
+        name="Engineering Hiring",
+        description="Focuses on robotics software and controls engineering roles.",
+        leads=["user-3"],
+    ),
+    Team(
+        id="team-operations",
+        employer_id="emp-1",
+        name="Operations Recruiting",
+        description="Supports plant operations and implementation staff hiring.",
+        leads=["user-4"],
+    ),
+]
+
+_JOBS: List[Job] = [
+    Job(
+        id="job-robotics-se",
+        employer_id="emp-1",
+        team_id="team-engineering",
+        title="Robotics Software Engineer",
+        description=(
+            "Own motion planning and perception algorithms for next-generation "
+            "assembly lines."
+        ),
+        status=JobStatus.OPEN,
+        openings=2,
+        location="Seattle, WA (Hybrid)",
+        created_at=datetime(2024, 1, 12, 14, 30, tzinfo=timezone.utc),
+        pipeline_id="pipe-robotics-se",
+        hiring_manager_id="user-3",
+    ),
+    Job(
+        id="job-controls-lead",
+        employer_id="emp-1",
+        team_id="team-engineering",
+        title="Controls Engineering Lead",
+        description="Lead PLC and controls architecture for automated manufacturing cells.",
+        status=JobStatus.OPEN,
+        openings=1,
+        location="Austin, TX",
+        created_at=datetime(2024, 2, 3, 9, 15, tzinfo=timezone.utc),
+        pipeline_id="pipe-controls-lead",
+        hiring_manager_id="user-3",
+    ),
+    Job(
+        id="job-ops-analyst",
+        employer_id="emp-1",
+        team_id="team-operations",
+        title="Manufacturing Operations Analyst",
+        description="Analyze deployment data and operational readiness for new lines.",
+        status=JobStatus.ON_HOLD,
+        openings=1,
+        location="Remote - North America",
+        created_at=datetime(2023, 12, 5, 16, 5, tzinfo=timezone.utc),
+        pipeline_id="pipe-ops-analyst",
+        hiring_manager_id="user-4",
+    ),
+]
+
+_PIPELINES: Dict[str, JobPipeline] = {
+    "job-robotics-se": JobPipeline(
+        id="pipe-robotics-se",
+        employer_id="emp-1",
+        job_id="job-robotics-se",
+        stages=[
+            PipelineStage(
+                id="stage-robotics-1",
+                name="Resume Review",
+                order=1,
+                description="Talent team screens resumes for robotics experience.",
+                exit_criteria="Meets robotics software prerequisites",
+            ),
+            PipelineStage(
+                id="stage-robotics-2",
+                name="Technical Phone Screen",
+                order=2,
+                description="Live coding and perception systems discussion.",
+                exit_criteria="Score of 3+ on evaluation rubric",
+            ),
+            PipelineStage(
+                id="stage-robotics-3",
+                name="Onsite Interview",
+                order=3,
+                description="Full-day onsite with cross-functional panel.",
+                exit_criteria="Green from two technical panels",
+            ),
+            PipelineStage(
+                id="stage-robotics-4",
+                name="Offer",
+                order=4,
+                description="Final approvals, compensation, and closing tasks.",
+            ),
+        ],
+    ),
+    "job-controls-lead": JobPipeline(
+        id="pipe-controls-lead",
+        employer_id="emp-1",
+        job_id="job-controls-lead",
+        stages=[
+            PipelineStage(
+                id="stage-controls-1",
+                name="Resume Review",
+                order=1,
+                description="Recruiting ops validates PLC project history.",
+            ),
+            PipelineStage(
+                id="stage-controls-2",
+                name="Panel Interview",
+                order=2,
+                description="Cross-disciplinary engineering panel interview.",
+            ),
+            PipelineStage(
+                id="stage-controls-3",
+                name="Leadership Round",
+                order=3,
+                description="Executive alignment and team leadership assessment.",
+            ),
+        ],
+    ),
+    "job-ops-analyst": JobPipeline(
+        id="pipe-ops-analyst",
+        employer_id="emp-1",
+        job_id="job-ops-analyst",
+        stages=[
+            PipelineStage(
+                id="stage-ops-1",
+                name="Resume Review",
+                order=1,
+                description="Operations team reviews analytics and Six Sigma background.",
+            ),
+            PipelineStage(
+                id="stage-ops-2",
+                name="Case Study",
+                order=2,
+                description="Timed scenario evaluating deployment throughput."
+            ),
+            PipelineStage(
+                id="stage-ops-3",
+                name="Final Interview",
+                order=3,
+                description="Panel with manufacturing leadership.",
+            ),
+        ],
+    ),
+}
+
+_APPLICATIONS: List[Application] = [
+    Application(
+        id="app-001",
+        employer_id="emp-1",
+        job_id="job-robotics-se",
+        candidate_name="Sasha Patel",
+        candidate_email="sasha.patel@example.com",
+        status=ApplicationStatus.SCREENING,
+        stage_id="stage-robotics-2",
+        submitted_at=datetime(2024, 2, 5, 17, 45, tzinfo=timezone.utc),
+        resume_url="https://files.autohire.dev/resumes/sasha-patel.pdf",
+        overall_score=3.7,
+    ),
+    Application(
+        id="app-002",
+        employer_id="emp-1",
+        job_id="job-robotics-se",
+        candidate_name="Kerry Johnson",
+        candidate_email="kerry.johnson@example.com",
+        status=ApplicationStatus.NEW,
+        stage_id="stage-robotics-1",
+        submitted_at=datetime(2024, 2, 8, 11, 12, tzinfo=timezone.utc),
+        resume_url="https://files.autohire.dev/resumes/kerry-johnson.pdf",
+    ),
+    Application(
+        id="app-003",
+        employer_id="emp-1",
+        job_id="job-controls-lead",
+        candidate_name="Omar Siddiqui",
+        candidate_email="omar.siddiqui@example.com",
+        status=ApplicationStatus.INTERVIEW,
+        stage_id="stage-controls-2",
+        submitted_at=datetime(2024, 1, 29, 15, 5, tzinfo=timezone.utc),
+        overall_score=4.2,
+    ),
+    Application(
+        id="app-004",
+        employer_id="emp-1",
+        job_id="job-ops-analyst",
+        candidate_name="Dana Flores",
+        candidate_email="dana.flores@example.com",
+        status=ApplicationStatus.SCREENING,
+        stage_id="stage-ops-1",
+        submitted_at=datetime(2023, 12, 21, 10, 40, tzinfo=timezone.utc),
+    ),
+]
+
+_MICROTASK_CAMPAIGNS: Dict[str, MicrotaskCampaign] = {
+    "camp-robotics-resume": MicrotaskCampaign(
+        id="camp-robotics-resume",
+        employer_id="emp-1",
+        job_id="job-robotics-se",
+        name="Robotics Resume Review Sprint",
+        description="Crowdsourced evaluation of robotics software candidate resumes.",
+        status=CampaignStatus.ACTIVE,
+        launch_date=datetime(2024, 2, 6, 13, 0, tzinfo=timezone.utc),
+        target_stage_id="stage-robotics-1",
+        tasks=[
+            Microtask(
+                id="task-robotics-1",
+                employer_id="emp-1",
+                campaign_id="camp-robotics-resume",
+                title="Evaluate robotics perception experience",
+                type=MicrotaskType.RESUME_REVIEW,
+                status=MicrotaskStatus.IN_PROGRESS,
+                instructions="Score perception and motion planning experience against rubric.",
+                assignee="worker-21",
+                related_application_id="app-001",
+                stage_id="stage-robotics-1",
+                due_at=datetime(2024, 2, 9, 23, 59, tzinfo=timezone.utc),
+                metadata={"resume_url": "https://files.autohire.dev/resumes/sasha-patel.pdf"},
+            ),
+            Microtask(
+                id="task-robotics-2",
+                employer_id="emp-1",
+                campaign_id="camp-robotics-resume",
+                title="Score robotics controls background",
+                type=MicrotaskType.RESUME_REVIEW,
+                status=MicrotaskStatus.PENDING,
+                instructions="Confirm PLC, C++, and ROS2 experience meets baseline.",
+                related_application_id="app-002",
+                stage_id="stage-robotics-1",
+                due_at=datetime(2024, 2, 10, 18, 0, tzinfo=timezone.utc),
+            ),
+        ],
+    ),
+    "camp-controls-calibration": MicrotaskCampaign(
+        id="camp-controls-calibration",
+        employer_id="emp-1",
+        job_id="job-controls-lead",
+        name="Controls Interview Calibration",
+        description="Align panel scoring for controls engineering leadership interviews.",
+        status=CampaignStatus.PAUSED,
+        launch_date=datetime(2024, 1, 18, 9, 30, tzinfo=timezone.utc),
+        target_stage_id="stage-controls-2",
+        tasks=[
+            Microtask(
+                id="task-controls-1",
+                employer_id="emp-1",
+                campaign_id="camp-controls-calibration",
+                title="Review panel rubric alignment",
+                type=MicrotaskType.DATA_ENRICHMENT,
+                status=MicrotaskStatus.COMPLETED,
+                instructions="Aggregate interviewer feedback for rubric improvement.",
+                assignee="worker-42",
+                stage_id="stage-controls-2",
+            ),
+            Microtask(
+                id="task-controls-2",
+                employer_id="emp-1",
+                campaign_id="camp-controls-calibration",
+                title="Score sample interview transcript",
+                type=MicrotaskType.STRUCTURED_INTERVIEW,
+                status=MicrotaskStatus.PENDING,
+                instructions="Score calibration interview using leadership rubric.",
+                stage_id="stage-controls-2",
+            ),
+        ],
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+def list_employers_for_user(user_id: str) -> List[Employer]:
+    """Return employers the supplied user belongs to."""
+
+    return [
+        employer
+        for employer in _EMPLOYERS.values()
+        if any(member.user_id == user_id for member in employer.members)
+    ]
+
+
+def get_employer(employer_id: str) -> Optional[Employer]:
+    """Fetch a single employer by its identifier."""
+
+    return _EMPLOYERS.get(employer_id)
+
+
+def get_employer_member(employer_id: str, user_id: str) -> Optional[EmployerMember]:
+    """Look up membership for a user within an employer."""
+
+    employer = get_employer(employer_id)
+    if not employer:
+        return None
+    return next((member for member in employer.members if member.user_id == user_id), None)
+
+
+def list_teams_for_employer(employer_id: str) -> List[Team]:
+    """Return all teams for an employer."""
+
+    return [team for team in _TEAMS if team.employer_id == employer_id]
+
+
+def get_team(employer_id: str, team_id: str) -> Optional[Team]:
+    """Retrieve a specific team ensuring it belongs to the employer."""
+
+    team = next((team for team in _TEAMS if team.id == team_id), None)
+    if team and team.employer_id == employer_id:
+        return team
+    return None
+
+
+def list_jobs_for_employer(employer_id: str) -> List[Job]:
+    """Return jobs scoped to the employer."""
+
+    return [job for job in _JOBS if job.employer_id == employer_id]
+
+
+def get_job_for_employer(employer_id: str, job_id: str) -> Optional[Job]:
+    """Fetch a job verifying it belongs to the employer."""
+
+    job = next((job for job in _JOBS if job.id == job_id), None)
+    if job and job.employer_id == employer_id:
+        return job
+    return None
+
+
+def get_job_pipeline(employer_id: str, job_id: str) -> Optional[JobPipeline]:
+    """Return the pipeline for a job if owned by the employer."""
+
+    pipeline = _PIPELINES.get(job_id)
+    if pipeline and pipeline.employer_id == employer_id:
+        return pipeline
+    return None
+
+
+def list_job_applications(employer_id: str, job_id: str) -> List[Application]:
+    """Retrieve applications for a job scoped to the employer."""
+
+    return [
+        application
+        for application in _APPLICATIONS
+        if application.job_id == job_id and application.employer_id == employer_id
+    ]
+
+
+def list_microtask_campaigns(employer_id: str) -> List[MicrotaskCampaign]:
+    """Return microtask campaigns for the employer."""
+
+    return [campaign for campaign in _MICROTASK_CAMPAIGNS.values() if campaign.employer_id == employer_id]
+
+
+def get_microtask_campaign(employer_id: str, campaign_id: str) -> Optional[MicrotaskCampaign]:
+    """Fetch a specific microtask campaign scoped to the employer."""
+
+    campaign = _MICROTASK_CAMPAIGNS.get(campaign_id)
+    if campaign and campaign.employer_id == employer_id:
+        return campaign
+    return None
+
+
+def list_microtasks_for_campaign(employer_id: str, campaign_id: str) -> List[Microtask]:
+    """Return microtasks for a campaign ensuring tenant isolation."""
+
+    campaign = get_microtask_campaign(employer_id, campaign_id)
+    return campaign.tasks if campaign else []
+
+
+# ---------------------------------------------------------------------------
+# Mutation helpers (stub implementations)
+# ---------------------------------------------------------------------------
+
+def create_job(employer_id: str, request: JobCreateRequest) -> Job:
+    """Create a job with a default pipeline for demonstration purposes."""
+
+    if not get_employer(employer_id):
+        raise ValueError("Employer does not exist.")
+
+    if not get_team(employer_id, request.team_id):
+        raise ValueError("Team does not belong to employer.")
+
+    job_id = f"job-{uuid4().hex[:8]}"
+    pipeline_id = f"pipe-{uuid4().hex[:8]}"
+    created_at = datetime.now(tz=timezone.utc)
+
+    job = Job(
+        id=job_id,
+        employer_id=employer_id,
+        team_id=request.team_id,
+        title=request.title,
+        description=request.description,
+        status=JobStatus.OPEN,
+        openings=request.openings,
+        location=request.location,
+        created_at=created_at,
+        pipeline_id=pipeline_id,
+    )
+
+    default_stages = [
+        PipelineStage(
+            id=f"{pipeline_id}-stage-1",
+            name="Resume Review",
+            order=1,
+            description="Recruiting review for basic qualifications.",
+        ),
+        PipelineStage(
+            id=f"{pipeline_id}-stage-2",
+            name="Phone Screen",
+            order=2,
+            description="Initial recruiter or hiring manager conversation.",
+        ),
+        PipelineStage(
+            id=f"{pipeline_id}-stage-3",
+            name="Interview Loop",
+            order=3,
+            description="Structured onsite or virtual interview loop.",
+        ),
+        PipelineStage(
+            id=f"{pipeline_id}-stage-4",
+            name="Offer",
+            order=4,
+            description="Final offer creation and approvals.",
+        ),
+    ]
+
+    pipeline = JobPipeline(
+        id=pipeline_id,
+        employer_id=employer_id,
+        job_id=job_id,
+        stages=default_stages,
+    )
+
+    _JOBS.append(job)
+    _PIPELINES[job_id] = pipeline
+
+    return job

--- a/apps/api/app/routes/__init__.py
+++ b/apps/api/app/routes/__init__.py
@@ -1,7 +1,19 @@
+"""Route configuration for the AutoHire API."""
+
 from fastapi import APIRouter
 
-from . import candidates, jobs
+from . import candidates, employers, jobs, microtasks
 
 api_router = APIRouter()
 api_router.include_router(candidates.router, prefix="/candidates", tags=["candidates"])
-api_router.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
+api_router.include_router(employers.router, prefix="/employers", tags=["employers"])
+api_router.include_router(
+    jobs.router,
+    prefix="/employers/{employer_id}/jobs",
+    tags=["jobs"],
+)
+api_router.include_router(
+    microtasks.router,
+    prefix="/employers/{employer_id}/microtasks",
+    tags=["microtasks"],
+)

--- a/apps/api/app/routes/dependencies.py
+++ b/apps/api/app/routes/dependencies.py
@@ -1,0 +1,63 @@
+"""Shared dependencies for route modules."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+
+from ..models import EmployerContext, EmployerRole, get_employer, get_employer_member
+
+UserIdHeader = Annotated[str, Header(alias="X-User-Id")]
+EmployerIdHeader = Annotated[str | None, Header(alias="X-Employer-Id")]
+
+
+async def get_current_user_id(user_id: UserIdHeader) -> str:
+    """Resolve the user identifier from request headers."""
+
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing user header")
+    return user_id
+
+
+async def require_employer_membership(
+    employer_id: str,
+    user_id: UserIdHeader,
+    employer_header: EmployerIdHeader = None,
+) -> EmployerContext:
+    """Ensure the current user is a member of the employer scope."""
+
+    if employer_header and employer_header != employer_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Employer scope mismatch between header and path.",
+        )
+
+    employer = get_employer(employer_id)
+    if not employer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Employer not found.")
+
+    member = get_employer_member(employer_id, user_id)
+    if not member:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not authorized for this employer.",
+        )
+
+    return EmployerContext(employer=employer, member=member)
+
+
+def require_roles(*roles: EmployerRole):
+    """Dependency ensuring the caller possesses at least one of the roles."""
+
+    required_roles = list(roles)
+
+    async def _checker(context: EmployerContext = Depends(require_employer_membership)) -> EmployerContext:
+        if required_roles and not any(role in context.member.roles for role in required_roles):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role to perform this action.",
+            )
+        return context
+
+    return _checker

--- a/apps/api/app/routes/employers.py
+++ b/apps/api/app/routes/employers.py
@@ -1,0 +1,37 @@
+"""Employer and team endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..models import Employer, Team, list_employers_for_user, list_teams_for_employer
+from .dependencies import EmployerContext, UserIdHeader, require_roles
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[Employer])
+async def list_employers(user_id: UserIdHeader) -> list[Employer]:
+    """Return employers the current user can access."""
+
+    return list_employers_for_user(user_id)
+
+
+@router.get("/{employer_id}", response_model=Employer)
+async def get_employer_detail(
+    employer_id: str,
+    context: EmployerContext = Depends(require_roles()),
+) -> Employer:
+    """Return details for a specific employer."""
+
+    return context.employer
+
+
+@router.get("/{employer_id}/teams", response_model=list[Team])
+async def get_employer_teams(
+    employer_id: str,
+    _context: EmployerContext = Depends(require_roles()),
+) -> list[Team]:
+    """List teams that belong to the employer."""
+
+    return list_teams_for_employer(employer_id)

--- a/apps/api/app/routes/jobs.py
+++ b/apps/api/app/routes/jobs.py
@@ -1,17 +1,107 @@
-from fastapi import APIRouter
+"""Job and pipeline endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..models import (
+    Application,
+    EmployerRole,
+    Job,
+    JobCreateRequest,
+    JobPipeline,
+    create_job,
+    get_job_for_employer,
+    get_job_pipeline,
+    list_job_applications,
+    list_jobs_for_employer,
+)
+from .dependencies import EmployerContext, require_roles
 
 router = APIRouter()
 
 
-@router.get("")
-async def list_jobs() -> dict[str, str]:
-    """Placeholder endpoint returning jobs using hybrid search filters."""
+@router.get("", response_model=list[Job])
+async def list_jobs(
+    employer_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(EmployerRole.OWNER, EmployerRole.RECRUITER, EmployerRole.HIRING_MANAGER)
+    ),
+) -> list[Job]:
+    """List jobs owned by the employer."""
 
-    return {"message": "Job listing endpoint stub."}
+    return list_jobs_for_employer(employer_id)
 
 
-@router.get("/{job_id}")
-async def get_job(job_id: str) -> dict[str, str]:
-    """Placeholder endpoint returning job detail."""
+@router.post("", response_model=Job, status_code=status.HTTP_201_CREATED)
+async def create_job_endpoint(
+    employer_id: str,
+    payload: JobCreateRequest,
+    _context: EmployerContext = Depends(require_roles(EmployerRole.OWNER, EmployerRole.RECRUITER)),
+) -> Job:
+    """Create a new job within the employer scope."""
 
-    return {"message": f"Details for job {job_id} will be served here."}
+    try:
+        return create_job(employer_id, payload)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/{job_id}", response_model=Job)
+async def get_job_detail(
+    employer_id: str,
+    job_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(
+            EmployerRole.OWNER,
+            EmployerRole.RECRUITER,
+            EmployerRole.HIRING_MANAGER,
+            EmployerRole.CONTRIBUTOR,
+        )
+    ),
+) -> Job:
+    """Return details for a job."""
+
+    job = get_job_for_employer(employer_id, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
+    return job
+
+
+@router.get("/{job_id}/pipeline", response_model=JobPipeline)
+async def get_job_pipeline_detail(
+    employer_id: str,
+    job_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(
+            EmployerRole.OWNER,
+            EmployerRole.RECRUITER,
+            EmployerRole.HIRING_MANAGER,
+            EmployerRole.CONTRIBUTOR,
+        )
+    ),
+) -> JobPipeline:
+    """Return the pipeline configuration for the job."""
+
+    pipeline = get_job_pipeline(employer_id, job_id)
+    if not pipeline:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pipeline not found.")
+    return pipeline
+
+
+@router.get("/{job_id}/applications", response_model=list[Application])
+async def list_job_application_detail(
+    employer_id: str,
+    job_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(EmployerRole.OWNER, EmployerRole.RECRUITER, EmployerRole.HIRING_MANAGER)
+    ),
+) -> list[Application]:
+    """Return applications submitted to the job."""
+
+    # ensure the job exists before returning applications
+    job = get_job_for_employer(employer_id, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
+
+    return list_job_applications(employer_id, job_id)

--- a/apps/api/app/routes/microtasks.py
+++ b/apps/api/app/routes/microtasks.py
@@ -1,0 +1,67 @@
+"""Microtask campaign endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..models import (
+    EmployerRole,
+    Microtask,
+    MicrotaskCampaign,
+    get_microtask_campaign,
+    list_microtask_campaigns,
+    list_microtasks_for_campaign,
+)
+from .dependencies import EmployerContext, require_roles
+
+router = APIRouter()
+
+
+@router.get("/campaigns", response_model=list[MicrotaskCampaign])
+async def list_campaigns(
+    employer_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(EmployerRole.OWNER, EmployerRole.RECRUITER, EmployerRole.HIRING_MANAGER)
+    ),
+) -> list[MicrotaskCampaign]:
+    """Return campaigns owned by the employer."""
+
+    return list_microtask_campaigns(employer_id)
+
+
+@router.get("/campaigns/{campaign_id}", response_model=MicrotaskCampaign)
+async def get_campaign_detail(
+    employer_id: str,
+    campaign_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(EmployerRole.OWNER, EmployerRole.RECRUITER, EmployerRole.HIRING_MANAGER)
+    ),
+) -> MicrotaskCampaign:
+    """Return a specific campaign."""
+
+    campaign = get_microtask_campaign(employer_id, campaign_id)
+    if not campaign:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+    return campaign
+
+
+@router.get("/campaigns/{campaign_id}/tasks", response_model=list[Microtask])
+async def list_campaign_tasks(
+    employer_id: str,
+    campaign_id: str,
+    _context: EmployerContext = Depends(
+        require_roles(
+            EmployerRole.OWNER,
+            EmployerRole.RECRUITER,
+            EmployerRole.HIRING_MANAGER,
+            EmployerRole.CONTRIBUTOR,
+        )
+    ),
+) -> list[Microtask]:
+    """Return tasks for the specified campaign."""
+
+    campaign = get_microtask_campaign(employer_id, campaign_id)
+    if not campaign:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+
+    return list_microtasks_for_campaign(employer_id, campaign_id)

--- a/apps/employer-portal/.eslintrc.json
+++ b/apps/employer-portal/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/employer-portal/app/(portal)/_components/JobCreationForm.tsx
+++ b/apps/employer-portal/app/(portal)/_components/JobCreationForm.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+
+import { createJob } from "@/lib/api";
+import type { JobCreateRequest, Team } from "@/lib/types";
+
+type JobCreationFormProps = {
+  employerId: string;
+  teams: Team[];
+};
+
+const baseState = {
+  title: "",
+  team_id: "",
+  location: "",
+  openings: 1,
+  description: "",
+};
+
+type FormStatus = "idle" | "submitting" | "success" | "error";
+
+export default function JobCreationForm({ employerId, teams }: JobCreationFormProps) {
+  const [formState, setFormState] = useState(() => ({
+    ...baseState,
+    team_id: teams[0]?.id ?? "",
+  }));
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({
+      ...prev,
+      [name]: name === "openings" ? Number(value) : value,
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const payload: JobCreateRequest = {
+      title: formState.title.trim(),
+      team_id: formState.team_id || teams[0]?.id || "",
+      location: formState.location.trim(),
+      openings: formState.openings || 1,
+      description: formState.description.trim() || undefined,
+    };
+
+    if (!payload.title || !payload.team_id || !payload.location) {
+      setMessage("Please provide a title, location, and select a team.");
+      setStatus("error");
+      return;
+    }
+
+    try {
+      setStatus("submitting");
+      await createJob(employerId, payload);
+      setStatus("success");
+      setMessage("Job created successfully. A default pipeline has been provisioned.");
+      setFormState({
+        ...baseState,
+        team_id: teams[0]?.id ?? "",
+      });
+    } catch (error) {
+      setStatus("error");
+      const detail = error instanceof Error ? error.message : "Unable to create job.";
+      setMessage(detail);
+    }
+  };
+
+  const disabled = status === "submitting";
+
+  return (
+    <form className="card form" onSubmit={handleSubmit}>
+      <div className="form-row">
+        <label htmlFor="title">Job title</label>
+        <input
+          id="title"
+          name="title"
+          value={formState.title}
+          onChange={handleChange}
+          placeholder="Robotics Software Engineer"
+          required
+        />
+      </div>
+      <div className="form-row">
+        <label htmlFor="team_id">Hiring team</label>
+        <select id="team_id" name="team_id" value={formState.team_id} onChange={handleChange} required>
+          <option value="" disabled>
+            Select a team
+          </option>
+          {teams.map((team) => (
+            <option key={team.id} value={team.id}>
+              {team.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="form-row three-col">
+        <div>
+          <label htmlFor="location">Location</label>
+          <input
+            id="location"
+            name="location"
+            value={formState.location}
+            onChange={handleChange}
+            placeholder="Seattle, WA (Hybrid)"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="openings">Openings</label>
+          <input
+            id="openings"
+            name="openings"
+            type="number"
+            min={1}
+            value={formState.openings}
+            onChange={handleChange}
+            required
+          />
+        </div>
+      </div>
+      <div className="form-row">
+        <label htmlFor="description">Summary</label>
+        <textarea
+          id="description"
+          name="description"
+          value={formState.description}
+          onChange={handleChange}
+          rows={4}
+          placeholder="Highlight the role mission, core skills, and key deliverables."
+        />
+      </div>
+      <button type="submit" disabled={disabled} className="primary">
+        {disabled ? "Creating job..." : "Create job"}
+      </button>
+      {message ? (
+        <p className={`form-message ${status}`}>{message}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/employer-portal/app/(portal)/jobs/new/page.tsx
+++ b/apps/employer-portal/app/(portal)/jobs/new/page.tsx
@@ -1,0 +1,33 @@
+import JobCreationForm from "@/app/(portal)/_components/JobCreationForm";
+import { fetchTeams } from "@/lib/api";
+import { requireEmployerRole } from "@/lib/auth";
+import type { EmployerRole } from "@/lib/types";
+
+const ALLOWED_ROLES: EmployerRole[] = ["owner", "recruiter"];
+
+export default async function JobCreationPage() {
+  const { employer } = await requireEmployerRole(ALLOWED_ROLES);
+  const teams = await fetchTeams(employer.id);
+
+  return (
+    <section className="stack">
+      <header className="page-header">
+        <div>
+          <h1>Create a job</h1>
+          <p className="lead">
+            Launch new openings for {employer.name}. Jobs automatically provision hiring pipelines and can
+            be synced to sourcing channels.
+          </p>
+        </div>
+      </header>
+      {teams.length ? (
+        <JobCreationForm employerId={employer.id} teams={teams} />
+      ) : (
+        <p className="hint">
+          You need at least one team configured before jobs can be created. Visit the organization setup page
+          to add hiring teams.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/employer-portal/app/(portal)/layout.tsx
+++ b/apps/employer-portal/app/(portal)/layout.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { formatRoles, requireEmployerRole } from "@/lib/auth";
+
+const NAV_LINKS = [
+  { href: "/org", label: "Organization setup" },
+  { href: "/jobs/new", label: "Job creation" },
+  { href: "/pipelines", label: "Pipeline management" },
+  { href: "/microtasks", label: "Microtask campaigns" },
+];
+
+type PortalLayoutProps = {
+  children: ReactNode;
+};
+
+export default async function PortalLayout({ children }: PortalLayoutProps) {
+  const { employer, member } = await requireEmployerRole();
+
+  const roleSummary = formatRoles(member.roles);
+
+  return (
+    <div className="portal-shell">
+      <aside className="portal-nav">
+        <div className="portal-profile">
+          <p className="portal-employer">{employer.name}</p>
+          <p className="portal-member">Signed in as {member.name}</p>
+          <p className="portal-roles">Roles: {roleSummary}</p>
+        </div>
+        <nav className="portal-links">
+          {NAV_LINKS.map((item) => (
+            <Link key={item.href} href={item.href} className="portal-link">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      <main className="portal-content">{children}</main>
+    </div>
+  );
+}

--- a/apps/employer-portal/app/(portal)/microtasks/page.tsx
+++ b/apps/employer-portal/app/(portal)/microtasks/page.tsx
@@ -1,0 +1,80 @@
+import { fetchMicrotaskCampaigns } from "@/lib/api";
+import { requireEmployerRole } from "@/lib/auth";
+import type { EmployerRole, MicrotaskCampaign } from "@/lib/types";
+
+const MICROTASK_ROLES: EmployerRole[] = ["owner", "recruiter", "hiring_manager"];
+
+const summarizeTasks = (campaign: MicrotaskCampaign) => {
+  const totals = campaign.tasks.reduce(
+    (acc, task) => {
+      acc[task.status] = (acc[task.status] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const parts = [
+    `${campaign.tasks.length} total`,
+    `${totals.pending ?? 0} pending`,
+    `${totals.in_progress ?? 0} in progress`,
+    `${totals.completed ?? 0} complete`,
+  ];
+
+  return parts.join(" • ");
+};
+
+export default async function MicrotaskCampaignPage() {
+  const { employer } = await requireEmployerRole(MICROTASK_ROLES);
+  const campaigns = await fetchMicrotaskCampaigns(employer.id);
+
+  return (
+    <section className="stack">
+      <header className="page-header">
+        <div>
+          <h1>Microtask campaigns</h1>
+          <p className="lead">
+            Coordinate sourcing and evaluation campaigns powered by the AutoHire worker network.
+          </p>
+        </div>
+      </header>
+      {campaigns.length ? (
+        <div className="card-grid">
+          {campaigns.map((campaign) => (
+            <article key={campaign.id} className="card">
+              <header className="card-header">
+                <div>
+                  <h2>{campaign.name}</h2>
+                  <p className="hint">Status: {campaign.status}</p>
+                </div>
+                {campaign.launch_date ? (
+                  <span className="list-meta">
+                    Launched {new Date(campaign.launch_date).toLocaleDateString()}
+                  </span>
+                ) : null}
+              </header>
+              <p>{campaign.description}</p>
+              <p className="hint">{summarizeTasks(campaign)}</p>
+              <div className="microtask-list">
+                {campaign.tasks.map((task) => (
+                  <div key={task.id} className="microtask-item">
+                    <p className="list-title">{task.title}</p>
+                    <p className="hint">Type: {task.type.replace(/_/g, " ")}</p>
+                    <p className="hint">Status: {task.status.replace("_", " ")}</p>
+                    {task.related_application_id ? (
+                      <p className="hint">Application: {task.related_application_id}</p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="hint">
+          No microtask campaigns have been launched yet. Use the API to configure sourcing or evaluation
+          projects, then monitor progress here.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/employer-portal/app/(portal)/org/page.tsx
+++ b/apps/employer-portal/app/(portal)/org/page.tsx
@@ -1,0 +1,91 @@
+import { fetchTeams } from "@/lib/api";
+import { formatRoles, requireEmployerRole } from "@/lib/auth";
+import type { EmployerMember, Team } from "@/lib/types";
+
+const formatMemberTeams = (member: EmployerMember, teams: Team[]) => {
+  if (!member.teams.length) {
+    return "No team assignments";
+  }
+
+  const teamNames = teams
+    .filter((team) => member.teams.includes(team.id))
+    .map((team) => team.name);
+
+  return teamNames.join(", ");
+};
+
+export default async function OrgSetupPage() {
+  const { employer } = await requireEmployerRole();
+  const teams = await fetchTeams(employer.id);
+  const memberLookup = new Map(employer.members.map((member) => [member.user_id, member.name]));
+
+  return (
+    <section className="stack">
+      <header className="page-header">
+        <div>
+          <h1>Organization setup</h1>
+          <p className="lead">
+            Configure teams, membership, and collaboration settings for {employer.name}.
+          </p>
+        </div>
+      </header>
+      <div className="card-grid">
+        <article className="card">
+          <h2>Employer profile</h2>
+          <dl className="details">
+            <div>
+              <dt>Domain</dt>
+              <dd>{employer.domain}</dd>
+            </div>
+            <div>
+              <dt>Description</dt>
+              <dd>{employer.description}</dd>
+            </div>
+            <div>
+              <dt>Total members</dt>
+              <dd>{employer.members.length}</dd>
+            </div>
+          </dl>
+          <p className="hint">
+            Use the API to update domains, brand assets, and identity integrations when provisioning new
+            organizations.
+          </p>
+        </article>
+        <article className="card">
+          <h2>Teams</h2>
+          <ul className="list">
+            {teams.map((team) => (
+              <li key={team.id}>
+                <div>
+                  <p className="list-title">{team.name}</p>
+                  <p className="hint">{team.description}</p>
+                </div>
+                <span className="list-meta">
+                  Leads:
+                  {team.leads.length
+                    ? ` ${team.leads.map((lead) => memberLookup.get(lead) ?? lead).join(", ")}`
+                    : " Assign a lead"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </article>
+        <article className="card">
+          <h2>Members</h2>
+          <ul className="list">
+            {employer.members.map((member) => (
+              <li key={member.user_id}>
+                <div>
+                  <p className="list-title">{member.name}</p>
+                  <p className="hint">{member.email}</p>
+                  <p className="hint">Teams: {formatMemberTeams(member, teams)}</p>
+                </div>
+                <span className="list-meta">{formatRoles(member.roles)}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/apps/employer-portal/app/(portal)/pipelines/page.tsx
+++ b/apps/employer-portal/app/(portal)/pipelines/page.tsx
@@ -1,0 +1,84 @@
+import { fetchJobApplications, fetchJobPipeline, fetchJobs } from "@/lib/api";
+import { requireEmployerRole } from "@/lib/auth";
+import type { EmployerRole, Job, JobPipeline } from "@/lib/types";
+
+const PIPELINE_ROLES: EmployerRole[] = ["owner", "recruiter", "hiring_manager"];
+
+type PipelineSummary = {
+  job: Job;
+  pipeline: JobPipeline;
+  stageCounts: { stageId: string; label: string; count: number }[];
+};
+
+export default async function PipelineManagementPage() {
+  const { employer } = await requireEmployerRole(PIPELINE_ROLES);
+  const jobs = await fetchJobs(employer.id);
+
+  if (!jobs.length) {
+    return (
+      <section className="stack">
+        <header className="page-header">
+          <h1>Pipeline management</h1>
+          <p className="lead">Create a job first to configure candidate pipelines.</p>
+        </header>
+        <p className="hint">
+          Jobs provision default pipelines that can be tuned for each role. Add customized stages to reflect
+          your screening workflow.
+        </p>
+      </section>
+    );
+  }
+
+  const pipelineSummaries: PipelineSummary[] = await Promise.all(
+    jobs.map(async (job) => {
+      const [pipeline, applications] = await Promise.all([
+        fetchJobPipeline(employer.id, job.id),
+        fetchJobApplications(employer.id, job.id),
+      ]);
+
+      const stageCounts = pipeline.stages.map((stage) => ({
+        stageId: stage.id,
+        label: stage.name,
+        count: applications.filter((application) => application.stage_id === stage.id).length,
+      }));
+
+      return { job, pipeline, stageCounts };
+    })
+  );
+
+  return (
+    <section className="stack">
+      <header className="page-header">
+        <div>
+          <h1>Pipeline management</h1>
+          <p className="lead">
+            Monitor stage progression and identify bottlenecks across jobs for {employer.name}.
+          </p>
+        </div>
+      </header>
+      <div className="stack">
+        {pipelineSummaries.map(({ job, pipeline, stageCounts }) => (
+          <article key={job.id} className="card">
+            <header className="card-header">
+              <div>
+                <h2>{job.title}</h2>
+                <p className="hint">
+                  {job.location} • {pipeline.stages.length} stages • {job.openings} open role
+                  {job.openings > 1 ? "s" : ""}
+                </p>
+              </div>
+            </header>
+            <div className="stage-list">
+              {stageCounts.map((stage) => (
+                <div key={stage.stageId} className="stage-pill">
+                  <p className="stage-name">{stage.label}</p>
+                  <p className="stage-count">{stage.count} applicants</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/employer-portal/app/globals.css
+++ b/apps/employer-portal/app/globals.css
@@ -19,3 +19,309 @@ a {
 * {
   box-sizing: border-box;
 }
+
+.portal-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.portal-nav {
+  width: 260px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  padding: 2.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  border-right: 1px solid rgba(15, 23, 42, 0.05);
+  box-shadow: 8px 0 32px rgba(15, 23, 42, 0.08);
+}
+
+.portal-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.portal-employer {
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.portal-member,
+.portal-roles {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.75);
+  font-size: 0.9rem;
+}
+
+.portal-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-link {
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.75rem;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.08);
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.portal-link:hover {
+  background: rgba(59, 130, 246, 0.2);
+  transform: translateX(4px);
+}
+
+.portal-content {
+  flex: 1;
+  padding: 3rem clamp(2rem, 5vw, 4.5rem);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+}
+
+.lead {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.7);
+  max-width: 60ch;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 0 0 1rem 0;
+}
+
+.details dt {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.details dd {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.hint {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.55);
+  font-size: 0.92rem;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.list-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.list-meta {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+  white-space: nowrap;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-row label {
+  font-weight: 600;
+}
+
+.form-row input,
+.form-row select,
+.form-row textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  font: inherit;
+  background: rgba(255, 255, 255, 0.95);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-row input:focus,
+.form-row select:focus,
+.form-row textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.65);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.three-col {
+  flex-direction: row;
+  gap: 1rem;
+}
+
+.three-col > div {
+  flex: 1;
+}
+
+.primary {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #2563eb, #4338ca);
+  border: none;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.3);
+}
+
+.form-message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.form-message.success {
+  color: #047857;
+}
+
+.form-message.error {
+  color: #dc2626;
+}
+
+.stage-list {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stage-pill {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(96, 165, 250, 0.15);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stage-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.stage-count {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.microtask-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.microtask-item {
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(15, 23, 42, 0.15);
+  background: rgba(241, 245, 249, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+@media (max-width: 960px) {
+  .portal-shell {
+    flex-direction: column;
+  }
+
+  .portal-nav {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .portal-links {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .portal-link {
+    flex: 1 1 200px;
+    text-align: center;
+  }
+}

--- a/apps/employer-portal/app/page.tsx
+++ b/apps/employer-portal/app/page.tsx
@@ -1,20 +1,5 @@
-export default function HomePage() {
-  return (
-    <main style={{ padding: "4rem", maxWidth: "960px", margin: "0 auto" }}>
-      <h1>AutoHire Employer Portal</h1>
-      <p>
-        This placeholder interface represents the future recruiter and hiring manager
-        experience. The production version will provide job authoring, applicant pipelines,
-        microtask campaigns, sourcing tools, scheduling, and OpenCATS synchronization.
-      </p>
-      <ul>
-        <li>Organization and team management</li>
-        <li>Job pipelines with screening workflows</li>
-        <li>Microtask campaign setup and review</li>
-      </ul>
-      <p>
-        Consult the documentation to understand how these capabilities will be implemented.
-      </p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+
+export default function IndexPage() {
+  redirect("/org");
 }

--- a/apps/employer-portal/lib/api.ts
+++ b/apps/employer-portal/lib/api.ts
@@ -1,0 +1,86 @@
+import { API_BASE_URL, DEMO_EMPLOYER_ID, DEMO_USER_ID } from "./config";
+import type {
+  Application,
+  Employer,
+  Job,
+  JobCreateRequest,
+  JobPipeline,
+  MicrotaskCampaign,
+  Team,
+} from "./types";
+
+const defaultHeaders = () => {
+  const headers = new Headers();
+  headers.set("X-User-Id", DEMO_USER_ID);
+  headers.set("X-Employer-Id", DEMO_EMPLOYER_ID);
+  return headers;
+};
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+  const headers = defaultHeaders();
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  }
+
+  const requestInit: RequestInit = {
+    cache: "no-store",
+    ...init,
+    headers,
+  };
+
+  if (requestInit.body && !(requestInit.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await fetch(url, requestInit);
+  if (!response.ok) {
+    let detail = `Request failed with status ${response.status}`;
+    try {
+      const payload = (await response.json()) as { detail?: string };
+      if (payload?.detail) {
+        detail = payload.detail;
+      }
+    } catch (error) {
+      // ignore JSON parsing errors for error handling fallback
+    }
+    throw new Error(detail);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function fetchEmployers(): Promise<Employer[]> {
+  return apiFetch<Employer[]>("/employers");
+}
+
+export async function fetchEmployer(employerId: string): Promise<Employer> {
+  return apiFetch<Employer>(`/employers/${employerId}`);
+}
+
+export async function fetchTeams(employerId: string): Promise<Team[]> {
+  return apiFetch<Team[]>(`/employers/${employerId}/teams`);
+}
+
+export async function fetchJobs(employerId: string): Promise<Job[]> {
+  return apiFetch<Job[]>(`/employers/${employerId}/jobs`);
+}
+
+export async function createJob(employerId: string, payload: JobCreateRequest): Promise<Job> {
+  return apiFetch<Job>(`/employers/${employerId}/jobs`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchJobPipeline(employerId: string, jobId: string): Promise<JobPipeline> {
+  return apiFetch<JobPipeline>(`/employers/${employerId}/jobs/${jobId}/pipeline`);
+}
+
+export async function fetchJobApplications(employerId: string, jobId: string): Promise<Application[]> {
+  return apiFetch<Application[]>(`/employers/${employerId}/jobs/${jobId}/applications`);
+}
+
+export async function fetchMicrotaskCampaigns(employerId: string): Promise<MicrotaskCampaign[]> {
+  return apiFetch<MicrotaskCampaign[]>(`/employers/${employerId}/microtasks/campaigns`);
+}

--- a/apps/employer-portal/lib/auth.ts
+++ b/apps/employer-portal/lib/auth.ts
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+
+import { fetchEmployer } from "@/lib/api";
+import { DEMO_EMPLOYER_ID, DEMO_USER_ID } from "@/lib/config";
+import { EMPLOYER_ROLE_LABELS, type Employer, type EmployerMember, type EmployerRole } from "@/lib/types";
+
+export type EmployerContext = {
+  employer: Employer;
+  member: EmployerMember;
+};
+
+export function formatRoles(roles: EmployerRole[]): string {
+  return roles.map((role) => EMPLOYER_ROLE_LABELS[role]).join(", ");
+}
+
+export async function requireEmployerRole(requiredRoles: EmployerRole[] = []): Promise<EmployerContext> {
+  const employer = await fetchEmployer(DEMO_EMPLOYER_ID);
+  const member = employer.members.find((entry) => entry.user_id === DEMO_USER_ID);
+
+  if (!member) {
+    notFound();
+  }
+
+  if (requiredRoles.length && !requiredRoles.some((role) => member.roles.includes(role))) {
+    notFound();
+  }
+
+  return { employer, member };
+}

--- a/apps/employer-portal/lib/config.ts
+++ b/apps/employer-portal/lib/config.ts
@@ -1,0 +1,3 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api";
+export const DEMO_USER_ID = process.env.NEXT_PUBLIC_DEMO_USER_ID ?? "user-2";
+export const DEMO_EMPLOYER_ID = process.env.NEXT_PUBLIC_DEMO_EMPLOYER_ID ?? "emp-1";

--- a/apps/employer-portal/lib/types.ts
+++ b/apps/employer-portal/lib/types.ts
@@ -1,0 +1,123 @@
+export type EmployerRole = "owner" | "recruiter" | "hiring_manager" | "contributor";
+
+export const EMPLOYER_ROLE_LABELS: Record<EmployerRole, string> = {
+  owner: "Owner",
+  recruiter: "Recruiter",
+  hiring_manager: "Hiring manager",
+  contributor: "Contributor",
+};
+
+export type EmployerMember = {
+  user_id: string;
+  email: string;
+  name: string;
+  roles: EmployerRole[];
+  teams: string[];
+};
+
+export type Employer = {
+  id: string;
+  name: string;
+  domain: string;
+  description?: string | null;
+  members: EmployerMember[];
+};
+
+export type Team = {
+  id: string;
+  employer_id: string;
+  name: string;
+  description?: string | null;
+  leads: string[];
+};
+
+export type JobStatus = "open" | "on_hold" | "closed";
+
+export type Job = {
+  id: string;
+  employer_id: string;
+  team_id: string;
+  title: string;
+  description?: string | null;
+  status: JobStatus;
+  openings: number;
+  location: string;
+  created_at: string;
+  pipeline_id: string;
+  hiring_manager_id?: string | null;
+};
+
+export type PipelineStage = {
+  id: string;
+  name: string;
+  order: number;
+  description?: string | null;
+  exit_criteria?: string | null;
+};
+
+export type JobPipeline = {
+  id: string;
+  employer_id: string;
+  job_id: string;
+  stages: PipelineStage[];
+};
+
+export type JobCreateRequest = {
+  title: string;
+  team_id: string;
+  location: string;
+  openings: number;
+  description?: string;
+};
+
+export type ApplicationStatus = "new" | "screening" | "interview" | "offer" | "hired" | "rejected";
+
+export type Application = {
+  id: string;
+  employer_id: string;
+  job_id: string;
+  candidate_name: string;
+  candidate_email: string;
+  status: ApplicationStatus;
+  stage_id: string;
+  submitted_at: string;
+  resume_url?: string | null;
+  overall_score?: number | null;
+};
+
+export type MicrotaskType =
+  | "resume_review"
+  | "structured_interview"
+  | "skill_validation"
+  | "data_enrichment";
+
+export type MicrotaskStatus = "pending" | "in_progress" | "completed";
+
+export type Microtask = {
+  id: string;
+  employer_id: string;
+  campaign_id: string;
+  title: string;
+  type: MicrotaskType;
+  status: MicrotaskStatus;
+  instructions: string;
+  assignee?: string | null;
+  related_application_id?: string | null;
+  stage_id?: string | null;
+  due_at?: string | null;
+  metadata: Record<string, string>;
+};
+
+export type CampaignStatus = "draft" | "active" | "paused" | "completed";
+
+export type MicrotaskCampaign = {
+  id: string;
+  employer_id: string;
+  job_id?: string | null;
+  name: string;
+  description: string;
+  status: CampaignStatus;
+  launch_date?: string | null;
+  target_stage_id?: string | null;
+  tasks: Microtask[];
+};

--- a/apps/employer-portal/next-env.d.ts
+++ b/apps/employer-portal/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/employer-portal/package.json
+++ b/apps/employer-portal/package.json
@@ -17,6 +17,8 @@
     "@types/node": "20.11.16",
     "@types/react": "18.2.47",
     "@types/react-dom": "18.2.18",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^15.5.4",
     "typescript": "5.3.3"
   }
 }

--- a/apps/employer-portal/tsconfig.json
+++ b/apps/employer-portal/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -11,8 +15,28 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "incremental": true,
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add in-memory employer, team, job, application, and microtask fixtures plus helper mutations
- expose employer, job, and microtask routers with header-based membership and role guards
- build routed employer portal views with shared API client, auth guard, and refreshed styling

## Testing
- PYTHONPATH=. pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d348c65e38832db88a3a9f18fe88f8