### PR TITLE
Implement scraping workflow and API ingestion endpoints

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,2 @@
+"""Top-level package marker for application modules."""
+

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Any, Dict, Iterable, Sequence
+from uuid import UUID, uuid4
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class JobProvenance:
+    run_id: str
+    adapter: str
+    scraped_at: datetime
+    ingested_at: datetime = field(default_factory=utcnow)
+    raw_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "adapter": self.adapter,
+            "scraped_at": self.scraped_at.isoformat(),
+            "ingested_at": self.ingested_at.isoformat(),
+            "raw_url": self.raw_url,
+        }
+
+
+@dataclass
+class JobRecord:
+    id: UUID
+    external_id: str
+    title: str
+    company: str
+    description: str
+    source_url: str
+    location: str | None
+    remote: bool | None
+    employment_type: str | None
+    salary_min: int | None
+    salary_max: int | None
+    currency: str | None
+    posted_at: datetime | None
+    scraped_at: datetime
+    source: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=utcnow)
+    updated_at: datetime = field(default_factory=utcnow)
+    provenance: list[JobProvenance] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "external_id": self.external_id,
+            "title": self.title,
+            "company": self.company,
+            "description": self.description,
+            "source_url": self.source_url,
+            "location": self.location,
+            "remote": self.remote,
+            "employment_type": self.employment_type,
+            "salary_min": self.salary_min,
+            "salary_max": self.salary_max,
+            "currency": self.currency,
+            "posted_at": self.posted_at.isoformat() if self.posted_at else None,
+            "scraped_at": self.scraped_at.isoformat(),
+            "source": self.source,
+            "metadata": self.metadata,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "provenance": [prov.to_dict() for prov in self.provenance],
+        }
+
+
+@dataclass
+class ScrapeRun:
+    id: str
+    adapter: str
+    received: int
+    created: int
+    updated: int
+    ignored: int
+    started_at: datetime
+    completed_at: datetime
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "adapter": self.adapter,
+            "received": self.received,
+            "created": self.created,
+            "updated": self.updated,
+            "ignored": self.ignored,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat(),
+        }
+
+
+@dataclass
+class ScrapeSchedule:
+    adapter: str
+    interval_minutes: int
+    enabled: bool = True
+    last_run_at: datetime | None = None
+    last_run_id: str | None = None
+    last_result: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "adapter": self.adapter,
+            "interval_minutes": self.interval_minutes,
+            "enabled": self.enabled,
+            "last_run_at": self.last_run_at.isoformat() if self.last_run_at else None,
+            "last_run_id": self.last_run_id,
+            "last_result": self.last_result,
+            "metadata": self.metadata,
+        }
+
+
+class JobStore:
+    def __init__(self) -> None:
+        self._jobs: Dict[UUID, JobRecord] = {}
+        self._jobs_by_external: Dict[str, JobRecord] = {}
+        self._runs: Dict[str, ScrapeRun] = {}
+        self._lock = RLock()
+
+    def list_jobs(self) -> list[JobRecord]:
+        with self._lock:
+            return list(self._jobs.values())
+
+    def get_job(self, job_id: str) -> JobRecord | None:
+        try:
+            uid = UUID(job_id)
+        except ValueError:
+            return None
+        with self._lock:
+            return self._jobs.get(uid)
+
+    def bulk_ingest(self, adapter: str, run_id: str, jobs: Sequence[dict[str, Any]]) -> ScrapeRun:
+        received = len(jobs)
+        created = 0
+        updated = 0
+        ignored = 0
+        earliest_scraped_at: datetime | None = None
+        fingerprints_seen: set[str] = set()
+
+        with self._lock:
+            for payload in jobs:
+                fingerprint = payload["external_id"]
+                if fingerprint in fingerprints_seen:
+                    ignored += 1
+                    continue
+                fingerprints_seen.add(fingerprint)
+
+                provenance = JobProvenance(
+                    run_id=run_id,
+                    adapter=adapter,
+                    scraped_at=payload.get("scraped_at", utcnow()),
+                    raw_url=payload.get("source_url"),
+                )
+                record, was_created = self._upsert(adapter, payload, provenance)
+                if was_created:
+                    created += 1
+                else:
+                    updated += 1
+                if earliest_scraped_at is None or provenance.scraped_at < earliest_scraped_at:
+                    earliest_scraped_at = provenance.scraped_at
+
+            run = ScrapeRun(
+                id=run_id,
+                adapter=adapter,
+                received=received,
+                created=created,
+                updated=updated,
+                ignored=ignored,
+                started_at=earliest_scraped_at or utcnow(),
+                completed_at=utcnow(),
+            )
+            self._runs[run_id] = run
+            return run
+
+    def _upsert(self, adapter: str, payload: dict[str, Any], provenance: JobProvenance) -> tuple[JobRecord, bool]:
+        fingerprint = payload["external_id"]
+        record = self._jobs_by_external.get(fingerprint)
+        if record is None:
+            record = self._create_record(adapter, payload)
+            self._jobs[record.id] = record
+            self._jobs_by_external[fingerprint] = record
+            created = True
+        else:
+            self._update_record(record, payload)
+            created = False
+        record.provenance.append(provenance)
+        return record, created
+
+    def _create_record(self, adapter: str, payload: dict[str, Any]) -> JobRecord:
+        return JobRecord(
+            id=uuid4(),
+            external_id=payload["external_id"],
+            title=payload["title"],
+            company=payload["company"],
+            description=payload["description"],
+            source_url=payload["source_url"],
+            location=payload.get("location"),
+            remote=payload.get("remote"),
+            employment_type=payload.get("employment_type"),
+            salary_min=payload.get("salary_min"),
+            salary_max=payload.get("salary_max"),
+            currency=payload.get("currency"),
+            posted_at=payload.get("posted_at"),
+            scraped_at=payload.get("scraped_at", utcnow()),
+            source=payload.get("source", adapter),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+    def _update_record(self, record: JobRecord, payload: dict[str, Any]) -> None:
+        record.title = payload["title"]
+        record.company = payload["company"]
+        record.description = payload["description"]
+        record.source_url = payload["source_url"]
+        record.location = payload.get("location")
+        record.remote = payload.get("remote")
+        record.employment_type = payload.get("employment_type")
+        record.salary_min = payload.get("salary_min")
+        record.salary_max = payload.get("salary_max")
+        record.currency = payload.get("currency")
+        record.posted_at = payload.get("posted_at")
+        record.scraped_at = payload.get("scraped_at", record.scraped_at)
+        record.source = payload.get("source", record.source)
+        record.metadata.update(payload.get("metadata") or {})
+        record.updated_at = utcnow()
+
+    def list_runs(self) -> list[ScrapeRun]:
+        with self._lock:
+            return list(self._runs.values())
+
+    def clear(self) -> None:
+        with self._lock:
+            self._jobs.clear()
+            self._jobs_by_external.clear()
+            self._runs.clear()
+
+
+class ScrapeScheduleStore:
+    def __init__(self, default_interval_minutes: int = 60) -> None:
+        self._entries: Dict[str, ScrapeSchedule] = {}
+        self._lock = RLock()
+        self._default_interval_minutes = default_interval_minutes
+
+    def list(self) -> list[ScrapeSchedule]:
+        with self._lock:
+            return list(self._entries.values())
+
+    def get(self, adapter: str) -> ScrapeSchedule | None:
+        with self._lock:
+            return self._entries.get(adapter)
+
+    def upsert_many(self, entries: Iterable[ScrapeSchedule]) -> list[ScrapeSchedule]:
+        with self._lock:
+            for entry in entries:
+                existing = self._entries.get(entry.adapter)
+                if existing:
+                    entry.last_run_at = existing.last_run_at
+                    entry.last_run_id = existing.last_run_id
+                    entry.last_result = existing.last_result
+                self._entries[entry.adapter] = entry
+            return list(self._entries.values())
+
+    def mark_run(self, run: ScrapeRun) -> ScrapeSchedule:
+        with self._lock:
+            entry = self._entries.get(run.adapter)
+            if entry is None:
+                entry = ScrapeSchedule(adapter=run.adapter, interval_minutes=self._default_interval_minutes)
+                self._entries[run.adapter] = entry
+            entry.last_run_at = run.completed_at
+            entry.last_run_id = run.id
+            entry.last_result = {
+                "received": run.received,
+                "created": run.created,
+                "updated": run.updated,
+                "ignored": run.ignored,
+            }
+            return entry
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+job_store = JobStore()
+schedule_store = ScrapeScheduleStore()
+
+
+def get_job_store() -> JobStore:
+    return job_store
+
+
+def get_schedule_store() -> ScrapeScheduleStore:
+    return schedule_store
+

--- a/apps/api/app/routes/jobs.py
+++ b/apps/api/app/routes/jobs.py
@@ -1,17 +1,193 @@
-from fastapi import APIRouter
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ..models import (
+    JobRecord,
+    ScrapeRun,
+    ScrapeSchedule,
+    get_job_store,
+    get_schedule_store,
+)
 
 router = APIRouter()
 
 
-@router.get("")
-async def list_jobs() -> dict[str, str]:
-    """Placeholder endpoint returning jobs using hybrid search filters."""
+class JobProvenanceResponse(BaseModel):
+    run_id: str
+    adapter: str
+    scraped_at: datetime
+    ingested_at: datetime
+    raw_url: str | None = None
 
-    return {"message": "Job listing endpoint stub."}
+
+class JobResponse(BaseModel):
+    id: str
+    external_id: str
+    title: str
+    company: str
+    description: str
+    source_url: str
+    location: str | None = None
+    remote: bool | None = None
+    employment_type: str | None = None
+    salary_min: int | None = None
+    salary_max: int | None = None
+    currency: str | None = None
+    posted_at: datetime | None = None
+    scraped_at: datetime
+    source: str
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    provenance: list[JobProvenanceResponse] = Field(default_factory=list)
 
 
-@router.get("/{job_id}")
-async def get_job(job_id: str) -> dict[str, str]:
-    """Placeholder endpoint returning job detail."""
+class JobListResponse(BaseModel):
+    jobs: list[JobResponse]
 
-    return {"message": f"Details for job {job_id} will be served here."}
+
+class JobIngestJob(BaseModel):
+    external_id: str
+    title: str
+    company: str
+    description: str
+    source_url: str
+    location: str | None = None
+    remote: bool | None = None
+    employment_type: str | None = None
+    salary_min: int | None = None
+    salary_max: int | None = None
+    currency: str | None = None
+    posted_at: datetime | None = None
+    scraped_at: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    source: str | None = None
+
+
+class JobIngestRequest(BaseModel):
+    adapter: str
+    run_id: str
+    jobs: list[JobIngestJob]
+
+
+class ScrapeRunResponse(BaseModel):
+    id: str
+    adapter: str
+    received: int
+    created: int
+    updated: int
+    ignored: int
+    started_at: datetime
+    completed_at: datetime
+
+
+class JobIngestResponse(BaseModel):
+    run: ScrapeRunResponse
+
+
+class ScrapeScheduleEntryPayload(BaseModel):
+    adapter: str
+    interval_minutes: int = Field(gt=0)
+    enabled: bool = True
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ScrapeScheduleCollectionPayload(BaseModel):
+    schedules: list[ScrapeScheduleEntryPayload]
+
+
+class ScrapeScheduleEntryResponse(BaseModel):
+    adapter: str
+    interval_minutes: int
+    enabled: bool
+    last_run_at: datetime | None = None
+    last_run_id: str | None = None
+    last_result: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ScrapeScheduleCollectionResponse(BaseModel):
+    schedules: list[ScrapeScheduleEntryResponse]
+
+
+class ScrapeRunListResponse(BaseModel):
+    runs: list[ScrapeRunResponse]
+
+
+def _job_to_response(record: JobRecord) -> JobResponse:
+    return JobResponse.model_validate(record.to_dict())
+
+
+def _run_to_response(run: ScrapeRun) -> ScrapeRunResponse:
+    return ScrapeRunResponse.model_validate(run.to_dict())
+
+
+def _schedule_to_response(schedule: ScrapeSchedule) -> ScrapeScheduleEntryResponse:
+    return ScrapeScheduleEntryResponse.model_validate(schedule.to_dict())
+
+
+@router.get("", response_model=JobListResponse)
+async def list_jobs() -> JobListResponse:
+    store = get_job_store()
+    jobs = [_job_to_response(job) for job in store.list_jobs()]
+    return JobListResponse(jobs=jobs)
+
+
+@router.post("/ingest", response_model=JobIngestResponse, status_code=status.HTTP_202_ACCEPTED)
+async def ingest_jobs(payload: JobIngestRequest) -> JobIngestResponse:
+    store = get_job_store()
+    schedule_store = get_schedule_store()
+    normalized_jobs: list[dict[str, Any]] = []
+    now = datetime.now(timezone.utc)
+    for job in payload.jobs:
+        data = job.model_dump()
+        data["scraped_at"] = data.get("scraped_at") or now
+        data["source"] = data.get("source") or payload.adapter
+        normalized_jobs.append(data)
+    run = store.bulk_ingest(payload.adapter, payload.run_id, normalized_jobs)
+    schedule_store.mark_run(run)
+    return JobIngestResponse(run=_run_to_response(run))
+
+
+@router.get("/runs", response_model=ScrapeRunListResponse)
+async def list_runs() -> ScrapeRunListResponse:
+    store = get_job_store()
+    runs = [_run_to_response(run) for run in store.list_runs()]
+    return ScrapeRunListResponse(runs=runs)
+
+
+@router.get("/schedule", response_model=ScrapeScheduleCollectionResponse)
+async def list_schedule() -> ScrapeScheduleCollectionResponse:
+    schedule_store = get_schedule_store()
+    schedules = [_schedule_to_response(entry) for entry in schedule_store.list()]
+    return ScrapeScheduleCollectionResponse(schedules=schedules)
+
+
+@router.put("/schedule", response_model=ScrapeScheduleCollectionResponse)
+async def update_schedule(payload: ScrapeScheduleCollectionPayload) -> ScrapeScheduleCollectionResponse:
+    schedule_store = get_schedule_store()
+    entries = [
+        ScrapeSchedule(
+            adapter=item.adapter,
+            interval_minutes=item.interval_minutes,
+            enabled=item.enabled,
+            metadata=item.metadata,
+        )
+        for item in payload.schedules
+    ]
+    updated = schedule_store.upsert_many(entries)
+    return ScrapeScheduleCollectionResponse(schedules=[_schedule_to_response(entry) for entry in updated])
+
+
+@router.get("/{job_id}", response_model=JobResponse)
+async def get_job(job_id: str) -> JobResponse:
+    store = get_job_store()
+    job = store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return _job_to_response(job)

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_DEFAULT_ENV = {
+    "DATABASE_URL": "postgresql://localhost/test",
+    "REDIS_URL": "redis://localhost:6379/0",
+    "MINIO_ENDPOINT": "http://minio:9000",
+    "MINIO_ACCESS_KEY": "minio",
+    "MINIO_SECRET_KEY": "minio123",
+    "MEILISEARCH_URL": "http://meilisearch:7700",
+    "MEILISEARCH_API_KEY": "test",
+    "QDRANT_URL": "http://qdrant:6333",
+    "KEYCLOAK_URL": "http://keycloak:8080",
+    "KEYCLOAK_REALM": "autohire",
+    "KEYCLOAK_CLIENT_ID": "autohire",
+    "KEYCLOAK_CLIENT_SECRET": "secret",
+}
+
+for env_key, env_value in _DEFAULT_ENV.items():
+    os.environ.setdefault(env_key, env_value)
+

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,6 +1,13 @@
+import sys
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
-from app.main import app
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from apps.api.app.main import app
 
 
 def test_health_endpoint() -> None:

--- a/apps/api/tests/test_jobs_ingestion.py
+++ b/apps/api/tests/test_jobs_ingestion.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from apps.api.app.main import app
+from apps.api.app.models import get_job_store, get_schedule_store
+
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    get_job_store().clear()
+    get_schedule_store().clear()
+
+
+def _sample_job_payload(external_id: str, title: str) -> dict[str, object]:
+    return {
+        "external_id": external_id,
+        "title": title,
+        "company": "Example Corp",
+        "description": "Role description",
+        "source_url": "https://jobs.example/demo",
+        "location": "Remote",
+        "remote": True,
+        "employment_type": "full_time",
+        "salary_min": 10000000,
+        "salary_max": 15000000,
+        "currency": "USD",
+        "posted_at": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        "metadata": {"test": True},
+    }
+
+
+def test_ingest_list_and_schedule_flow() -> None:
+    run_id = "run-1"
+    payload = {
+        "adapter": "demo-board",
+        "run_id": run_id,
+        "jobs": [_sample_job_payload("job-123", "Senior Platform Engineer")],
+    }
+    response = client.post("/api/jobs/ingest", json=payload)
+    assert response.status_code == 202
+    body = response.json()
+    assert body["run"]["id"] == run_id
+    assert body["run"]["created"] == 1
+    assert body["run"]["updated"] == 0
+
+    list_response = client.get("/api/jobs")
+    assert list_response.status_code == 200
+    jobs = list_response.json()["jobs"]
+    assert len(jobs) == 1
+    job_id = jobs[0]["id"]
+
+    detail_response = client.get(f"/api/jobs/{job_id}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["external_id"] == "job-123"
+
+    runs_response = client.get("/api/jobs/runs")
+    assert runs_response.status_code == 200
+    runs = runs_response.json()["runs"]
+    assert len(runs) == 1
+
+    schedule_response = client.get("/api/jobs/schedule")
+    assert schedule_response.status_code == 200
+    schedules = schedule_response.json()["schedules"]
+    assert len(schedules) == 1
+    assert schedules[0]["last_run_id"] == run_id
+
+    update_payload = {
+        "schedules": [
+            {"adapter": "demo-board", "interval_minutes": 15, "enabled": True, "metadata": {"priority": "high"}}
+        ]
+    }
+    put_response = client.put("/api/jobs/schedule", json=update_payload)
+    assert put_response.status_code == 200
+    updated_schedule = put_response.json()["schedules"][0]
+    assert updated_schedule["interval_minutes"] == 15
+    assert updated_schedule["metadata"]["priority"] == "high"
+    assert updated_schedule["last_run_id"] == run_id
+
+    second_run_id = "run-2"
+    second_payload = {
+        "adapter": "demo-board",
+        "run_id": second_run_id,
+        "jobs": [_sample_job_payload("job-123", "Principal Platform Engineer")],
+    }
+    second_response = client.post("/api/jobs/ingest", json=second_payload)
+    assert second_response.status_code == 202
+    second_body = second_response.json()
+    assert second_body["run"]["created"] == 0
+    assert second_body["run"]["updated"] == 1
+
+    detail_after_second = client.get(f"/api/jobs/{job_id}")
+    assert detail_after_second.status_code == 200
+    assert detail_after_second.json()["title"] == "Principal Platform Engineer"
+
+    schedule_after_second = client.get("/api/jobs/schedule")
+    assert schedule_after_second.status_code == 200
+    assert schedule_after_second.json()["schedules"][0]["last_run_id"] == second_run_id

--- a/apps/worker/app/api_client.py
+++ b/apps/worker/app/api_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import httpx
+
+from .config import WorkerSettings
+from .schemas import NormalizedJob
+from .scraping.schedule import ScrapeScheduleEntry
+
+
+class JobApiClient:
+    """HTTP client responsible for communicating with the AutoHire API service."""
+
+    def __init__(self, settings: WorkerSettings):
+        headers = {"User-Agent": "autohire-worker/0.1"}
+        if settings.api_token:
+            headers["Authorization"] = f"Bearer {settings.api_token}"
+        self._client = httpx.AsyncClient(
+            base_url=settings.api_base_url,
+            headers=headers,
+            timeout=settings.request_timeout_seconds,
+        )
+
+    async def ingest_jobs(self, adapter: str, run_id: str, jobs: Iterable[NormalizedJob]) -> dict:
+        payload = {
+            "adapter": adapter,
+            "run_id": run_id,
+            "jobs": [job.model_dump(mode="json") for job in jobs],
+        }
+        response = await self._client.post("/api/jobs/ingest", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def fetch_schedule(self) -> list[ScrapeScheduleEntry]:
+        response = await self._client.get("/api/jobs/schedule")
+        response.raise_for_status()
+        data = response.json()
+        schedules = data.get("schedules", [])
+        return [ScrapeScheduleEntry.model_validate(entry) for entry in schedules]
+
+    async def close(self) -> None:
+        await self._client.aclose()
+

--- a/apps/worker/app/config.py
+++ b/apps/worker/app/config.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class WorkerSettings(BaseSettings):
+    """Runtime configuration for the worker service."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    api_base_url: str = Field(default="http://api:8000", validation_alias=AliasChoices("API_BASE_URL", "api_base_url"))
+    api_token: str | None = Field(default=None, validation_alias=AliasChoices("API_TOKEN", "api_token"))
+    redis_url: str = Field(default="redis://redis:6379/0", validation_alias=AliasChoices("REDIS_URL", "redis_url"))
+    scrape_dispatch_interval_seconds: int = Field(
+        default=60,
+        ge=5,
+        description="How frequently Celery beat evaluates scraping schedules.",
+        validation_alias=AliasChoices("SCRAPE_DISPATCH_INTERVAL_SECONDS", "scrape_dispatch_interval_seconds"),
+    )
+    default_scrape_interval_minutes: int = Field(
+        default=60,
+        ge=1,
+        description="Fallback cadence when no explicit schedule exists for an adapter.",
+        validation_alias=AliasChoices("DEFAULT_SCRAPE_INTERVAL_MINUTES", "default_scrape_interval_minutes"),
+    )
+    request_timeout_seconds: float = Field(
+        default=20.0,
+        gt=0,
+        description="HTTP timeout when communicating with the API service.",
+        validation_alias=AliasChoices("REQUEST_TIMEOUT_SECONDS", "request_timeout_seconds"),
+    )
+    playwright_browser: Literal["chromium", "firefox", "webkit"] = Field(
+        default="chromium",
+        validation_alias=AliasChoices("PLAYWRIGHT_BROWSER", "playwright_browser"),
+    )
+    dedupe_ttl_hours: int = Field(
+        default=24,
+        ge=1,
+        description="How long scraped job fingerprints remain in Redis for deduplication.",
+        validation_alias=AliasChoices("SCRAPE_DEDUPE_TTL_HOURS", "dedupe_ttl_hours"),
+    )
+    scrape_queue_name: str = Field(
+        default="scrape",
+        min_length=1,
+        validation_alias=AliasChoices("SCRAPE_QUEUE_NAME", "scrape_queue_name"),
+    )
+
+
+@lru_cache
+def get_settings() -> WorkerSettings:
+    """Return a cached instance of :class:`WorkerSettings`."""
+
+    return WorkerSettings()  # type: ignore[arg-type]
+

--- a/apps/worker/app/schemas.py
+++ b/apps/worker/app/schemas.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class NormalizedJob(BaseModel):
+    """Normalized job representation shared with the API ingestion endpoint."""
+
+    external_id: str = Field(..., description="Stable identifier from the upstream source.")
+    title: str = Field(..., description="Job title as published by the source.")
+    company: str = Field(..., description="Hiring company or organization name.")
+    description: str = Field(..., description="HTML or plaintext job description body.")
+    source_url: str = Field(..., description="Canonical URL for the job posting.")
+    location: str | None = Field(default=None, description="Free-form location string supplied by the source.")
+    remote: bool | None = Field(default=None, description="Whether the posting advertises remote work.")
+    employment_type: str | None = Field(default=None, description="Employment type such as full-time or contract.")
+    salary_min: int | None = Field(default=None, description="Minimum salary or rate expressed in minor currency units.")
+    salary_max: int | None = Field(default=None, description="Maximum salary or rate expressed in minor currency units.")
+    currency: str | None = Field(default=None, description="ISO-4217 currency code if compensation is provided.")
+    posted_at: datetime | None = Field(default=None, description="Datetime supplied by the source for when the job was posted.")
+    scraped_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Timestamp recorded when the worker normalized the job.",
+    )
+    source: str | None = Field(default=None, description="Adapter slug responsible for scraping the job.")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary adapter-specific metadata retained for diagnostics.",
+    )
+
+
+class ScrapeRunResult(BaseModel):
+    """Return payload for completed scrape tasks."""
+
+    adapter: str
+    run_id: str
+    processed: int
+    sent: int
+    dropped: int
+    ingestion_response: dict[str, Any] | None = None
+
+
+class ScrapeDispatchSummary(BaseModel):
+    """Summary returned by the schedule dispatcher task."""
+
+    evaluated: int
+    dispatched: int
+    skipped: int
+    details: list[dict[str, Any]] = Field(default_factory=list)
+

--- a/apps/worker/app/scraping/__init__.py
+++ b/apps/worker/app/scraping/__init__.py
@@ -1,0 +1,7 @@
+"""Scraping orchestration utilities for the worker service."""
+
+from .service import dispatch_scheduled_scrapes, execute_scrape
+from .schedule import ScrapeScheduleEntry
+
+__all__ = ["dispatch_scheduled_scrapes", "execute_scrape", "ScrapeScheduleEntry"]
+

--- a/apps/worker/app/scraping/adapters/__init__.py
+++ b/apps/worker/app/scraping/adapters/__init__.py
@@ -1,0 +1,26 @@
+"""Adapter registry for Playwright-powered job board scrapers."""
+
+from .base import AdapterContext, BaseSiteAdapter, ScraperException
+from .demo import DemoBoardAdapter
+
+ADAPTER_REGISTRY: dict[str, type[BaseSiteAdapter]] = {
+    DemoBoardAdapter.slug: DemoBoardAdapter,
+}
+
+
+def get_adapter(slug: str) -> type[BaseSiteAdapter]:
+    try:
+        return ADAPTER_REGISTRY[slug]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ScraperException(f"Unknown adapter requested: {slug}") from exc
+
+
+__all__ = [
+    "AdapterContext",
+    "ADAPTER_REGISTRY",
+    "BaseSiteAdapter",
+    "DemoBoardAdapter",
+    "ScraperException",
+    "get_adapter",
+]
+

--- a/apps/worker/app/scraping/adapters/base.py
+++ b/apps/worker/app/scraping/adapters/base.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+from playwright.async_api import Playwright
+
+from ...schemas import NormalizedJob
+
+logger = logging.getLogger(__name__)
+
+
+class ScraperException(Exception):
+    """Raised when an adapter fails in a recoverable way."""
+
+
+@dataclass(slots=True)
+class AdapterContext:
+    """Shared contextual data made available to scraping adapters."""
+
+    rate_limit: "RateLimiter"
+    browser_name: str = "chromium"
+
+    async def throttle(self) -> None:
+        """Wait until the rate limiter allows another outbound request."""
+
+        await self.rate_limit.acquire()
+
+
+class BaseSiteAdapter(ABC):
+    """Base class for job board scrapers powered by Playwright."""
+
+    slug: str
+    display_name: str
+    rate_limit_per_minute: int = 30
+    dedupe_ttl_seconds: int = 60 * 60 * 24
+
+    def __init__(self, context: AdapterContext):
+        self.context = context
+
+    @abstractmethod
+    async def scrape(self, playwright: Playwright) -> AsyncIterator[NormalizedJob]:
+        """Yield normalized jobs discovered by the adapter."""
+
+    def dedupe_key(self, job: NormalizedJob) -> str:
+        """Fingerprint used to deduplicate jobs downstream."""
+
+        return job.external_id or job.source_url
+
+    async def throttle(self) -> None:
+        """Convenience wrapper used by subclasses."""
+
+        await self.context.throttle()
+
+
+from ..limiters import RateLimiter  # noqa: E402  (circular-friendly import)
+

--- a/apps/worker/app/scraping/adapters/demo.py
+++ b/apps/worker/app/scraping/adapters/demo.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from playwright.async_api import Playwright
+
+from ...schemas import NormalizedJob
+from .base import AdapterContext, BaseSiteAdapter
+
+
+class DemoBoardAdapter(BaseSiteAdapter):
+    """Reference adapter that demonstrates scraping workflow expectations."""
+
+    slug = "demo-board"
+    display_name = "Demo Job Board"
+    rate_limit_per_minute = 10
+
+    def __init__(self, context: AdapterContext):
+        super().__init__(context)
+        self._html_document = """
+            <html>
+                <body>
+                    <ul id="jobs">
+                        <li data-id="demo-1" data-url="https://jobs.example/demo-1">
+                            <h2>Senior Platform Engineer</h2>
+                            <span class="company">Example Corp</span>
+                            <span class="location">Remote - North America</span>
+                        </li>
+                        <li data-id="demo-2" data-url="https://jobs.example/demo-2">
+                            <h2>Product Designer</h2>
+                            <span class="company">Example Corp</span>
+                            <span class="location">Austin, TX</span>
+                        </li>
+                    </ul>
+                </body>
+            </html>
+        """
+
+    async def scrape(self, playwright: Playwright) -> AsyncIterator[NormalizedJob]:
+        browser_type = getattr(playwright, self.context.browser_name)
+        browser = await browser_type.launch(headless=True)
+        page = await browser.new_page()
+        try:
+            await page.goto(f"data:text/html,{self._html_document}")
+            listings = await page.eval_on_selector_all(
+                "#jobs li",
+                "els => els.map(el => ({\n"
+                "    id: el.getAttribute('data-id'),\n"
+                "    url: el.getAttribute('data-url'),\n"
+                "    title: el.querySelector('h2')?.textContent?.trim(),\n"
+                "    company: el.querySelector('.company')?.textContent?.trim(),\n"
+                "    location: el.querySelector('.location')?.textContent?.trim(),\n"
+                "}))",
+            )
+            now = datetime.now(timezone.utc)
+            for listing in listings:
+                yield NormalizedJob(
+                    external_id=listing["id"],
+                    title=listing["title"],
+                    company=listing["company"],
+                    description="Demo listing generated for integration tests.",
+                    source_url=listing["url"],
+                    location=listing["location"],
+                    remote="Remote" in (listing.get("location") or ""),
+                    employment_type="full_time",
+                    scraped_at=now,
+                    metadata={"demo": True},
+                )
+        finally:
+            await page.close()
+            await browser.close()
+

--- a/apps/worker/app/scraping/dedupe.py
+++ b/apps/worker/app/scraping/dedupe.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from redis.asyncio import Redis
+
+
+class JobDeduper:
+    """Redis-backed helper ensuring duplicate job payloads are ignored."""
+
+    def __init__(self, redis: Redis, namespace: str = "scrape:dedupe", ttl_seconds: int = 60 * 60 * 24):
+        self.redis = redis
+        self.namespace = namespace
+        self.ttl_seconds = ttl_seconds
+
+    async def is_duplicate(self, fingerprint: str) -> bool:
+        key = f"{self.namespace}:{fingerprint}"
+        added = await self.redis.set(key, "1", nx=True, ex=self.ttl_seconds)
+        return added is None
+
+    async def reset(self, fingerprint: str) -> None:
+        key = f"{self.namespace}:{fingerprint}"
+        await self.redis.expire(key, timedelta(seconds=self.ttl_seconds))
+

--- a/apps/worker/app/scraping/limiters.py
+++ b/apps/worker/app/scraping/limiters.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter shared by scraping adapters."""
+
+    def __init__(self, max_calls: int, period: float = 60.0):
+        self.max_calls = max_calls
+        self.period = period
+        self._events: dict[str, deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, key: str = "default") -> None:
+        if self.max_calls <= 0:
+            return
+
+        async with self._lock:
+            now = time.monotonic()
+            events = self._events.setdefault(key, deque())
+            while events and now - events[0] > self.period:
+                events.popleft()
+            if len(events) < self.max_calls:
+                events.append(now)
+                return
+            sleep_for = self.period - (now - events[0])
+
+        await asyncio.sleep(max(sleep_for, 0))
+        await self.acquire(key)
+

--- a/apps/worker/app/scraping/schedule.py
+++ b/apps/worker/app/scraping/schedule.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ScrapeScheduleEntry(BaseModel):
+    """Represents adapter cadence configuration fetched from the API."""
+
+    adapter: str
+    interval_minutes: int = Field(gt=0)
+    enabled: bool = True
+    last_run_at: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def is_due(self, last_dispatch_at: datetime | None, now: datetime | None = None) -> bool:
+        if not self.enabled:
+            return False
+        reference = last_dispatch_at or self.last_run_at
+        now = now or datetime.now(timezone.utc)
+        if reference is None:
+            return True
+        elapsed = now - reference
+        return elapsed.total_seconds() >= self.interval_minutes * 60
+
+
+class ScrapeDispatchRecord(BaseModel):
+    adapter: str
+    run_id: str | None = None
+    dispatched: bool = False
+    reason: str | None = None
+

--- a/apps/worker/app/scraping/service.py
+++ b/apps/worker/app/scraping/service.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from celery import Celery
+from playwright.async_api import async_playwright
+from redis.asyncio import Redis
+
+from ..api_client import JobApiClient
+from ..config import WorkerSettings
+from ..schemas import ScrapeDispatchSummary, ScrapeRunResult
+from .adapters import ADAPTER_REGISTRY, AdapterContext, get_adapter
+from .dedupe import JobDeduper
+from .limiters import RateLimiter
+from .schedule import ScrapeDispatchRecord, ScrapeScheduleEntry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScraperRuntime:
+    settings: WorkerSettings
+    api_client: JobApiClient
+    redis: Redis
+
+
+@asynccontextmanager
+async def build_runtime(settings: WorkerSettings):
+    redis = Redis.from_url(settings.redis_url, decode_responses=True)
+    api_client = JobApiClient(settings)
+    try:
+        yield ScraperRuntime(settings=settings, api_client=api_client, redis=redis)
+    finally:
+        await api_client.close()
+        await redis.aclose()
+
+
+class ScrapeService:
+    def __init__(self, runtime: ScraperRuntime):
+        self.runtime = runtime
+
+    async def run_adapter(self, adapter_slug: str, run_id: str | None = None) -> ScrapeRunResult:
+        adapter_cls = get_adapter(adapter_slug)
+        rate_limiter = RateLimiter(adapter_cls.rate_limit_per_minute)
+        dedupe = JobDeduper(
+            self.runtime.redis,
+            namespace=f"scrape:dedupe:{adapter_slug}",
+            ttl_seconds=adapter_cls.dedupe_ttl_seconds,
+        )
+        context = AdapterContext(rate_limit=rate_limiter, browser_name=self.runtime.settings.playwright_browser)
+        adapter = adapter_cls(context)
+        processed = 0
+        dropped = 0
+        collected: list[NormalizedJob] = []
+        run_id = run_id or str(uuid4())
+
+        async with async_playwright() as playwright:
+            if not hasattr(playwright, context.browser_name):
+                raise ValueError(
+                    f"Unsupported browser '{context.browser_name}' for Playwright context"
+                )
+            async for job in adapter.scrape(playwright):
+                processed += 1
+                job.source = adapter.slug
+                fingerprint = adapter.dedupe_key(job)
+                if await dedupe.is_duplicate(fingerprint):
+                    dropped += 1
+                    continue
+                collected.append(job)
+
+        ingestion_response: dict | None = None
+        if collected:
+            ingestion_response = await self.runtime.api_client.ingest_jobs(adapter.slug, run_id, collected)
+
+        logger.info(
+            "scrape-run-complete",
+            extra={
+                "adapter": adapter.slug,
+                "run_id": run_id,
+                "processed": processed,
+                "sent": len(collected),
+                "dropped": dropped,
+            },
+        )
+        return ScrapeRunResult(
+            adapter=adapter.slug,
+            run_id=run_id,
+            processed=processed,
+            sent=len(collected),
+            dropped=dropped,
+            ingestion_response=ingestion_response,
+        )
+
+class ScheduleDispatcher:
+    def __init__(self, runtime: ScraperRuntime, celery_app: Celery):
+        self.runtime = runtime
+        self.celery_app = celery_app
+
+    async def dispatch(self) -> ScrapeDispatchSummary:
+        schedules = await self.runtime.api_client.fetch_schedule()
+        if not schedules:
+            schedules = [
+                ScrapeScheduleEntry(
+                    adapter=adapter_slug,
+                    interval_minutes=self.runtime.settings.default_scrape_interval_minutes,
+                    enabled=True,
+                )
+                for adapter_slug in ADAPTER_REGISTRY.keys()
+            ]
+        now = datetime.now(timezone.utc)
+        details: list[dict] = []
+        dispatched = 0
+        for entry in schedules:
+            record = await self._handle_entry(entry, now)
+            if record.dispatched:
+                dispatched += 1
+            details.append(record.model_dump())
+        logger.info(
+            "scrape-dispatch-complete",
+            extra={"evaluated": len(schedules), "dispatched": dispatched, "skipped": len(schedules) - dispatched},
+        )
+        skipped = len(schedules) - dispatched
+        return ScrapeDispatchSummary(evaluated=len(schedules), dispatched=dispatched, skipped=skipped, details=details)
+
+    async def _handle_entry(self, entry: ScrapeScheduleEntry, now: datetime) -> ScrapeDispatchRecord:
+        redis_key = f"scrape:last_dispatch:{entry.adapter}"
+        raw_last_run = await self.runtime.redis.get(redis_key)
+        last_dispatched_at = datetime.fromisoformat(raw_last_run) if raw_last_run else None
+        if not entry.is_due(last_dispatched_at, now):
+            return ScrapeDispatchRecord(adapter=entry.adapter, dispatched=False, reason="not_due")
+
+        run_id = str(uuid4())
+        self.celery_app.send_task(
+            "autohire.scrape.run",
+            kwargs={"adapter_name": entry.adapter, "run_id": run_id},
+            queue=self.runtime.settings.scrape_queue_name,
+        )
+        await self.runtime.redis.set(redis_key, now.isoformat(), ex=int(entry.interval_minutes * 60))
+        return ScrapeDispatchRecord(adapter=entry.adapter, run_id=run_id, dispatched=True)
+
+
+async def execute_scrape(adapter_name: str, settings: WorkerSettings, run_id: str | None = None) -> ScrapeRunResult:
+    async with build_runtime(settings) as runtime:
+        service = ScrapeService(runtime)
+        return await service.run_adapter(adapter_name, run_id)
+
+
+async def dispatch_scheduled_scrapes(celery_app: Celery, settings: WorkerSettings) -> ScrapeDispatchSummary:
+    async with build_runtime(settings) as runtime:
+        dispatcher = ScheduleDispatcher(runtime, celery_app)
+        return await dispatcher.dispatch()
+

--- a/apps/worker/app/worker.py
+++ b/apps/worker/app/worker.py
@@ -1,19 +1,65 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+from typing import Any
 
 from celery import Celery
+from kombu import Queue
+
+from .config import get_settings
+from .scraping import dispatch_scheduled_scrapes, execute_scrape
+
+logger = logging.getLogger(__name__)
 
 CELERY_BROKER_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 CELERY_BACKEND_URL = CELERY_BROKER_URL
 
 celery_app = Celery("autohire", broker=CELERY_BROKER_URL, backend=CELERY_BACKEND_URL)
-celery_app.conf.task_default_queue = "default"
-celery_app.conf.result_expires = 3600
+settings = get_settings()
+
+celery_app.conf.update(
+    task_default_queue="default",
+    result_expires=3600,
+    task_queues=(Queue("default"), Queue(settings.scrape_queue_name)),
+    beat_schedule={
+        "dispatch-scrape-jobs": {
+            "task": "autohire.scrape.dispatch",
+            "schedule": settings.scrape_dispatch_interval_seconds,
+            "options": {"queue": settings.scrape_queue_name},
+        }
+    },
+    timezone="UTC",
+)
 
 
-@celery_app.task(name="autohire.echo")
+@celery_app.task(name="autohire.echo", queue="default")
 def echo(message: str) -> str:
     """Simple heartbeat task for smoke testing the worker stack."""
 
     return message
+
+
+@celery_app.task(name="autohire.scrape.run", queue=settings.scrape_queue_name)
+def run_scrape(adapter_name: str, run_id: str | None = None) -> dict[str, Any]:
+    """Execute a scraping adapter and persist results via the API."""
+
+    try:
+        result = asyncio.run(execute_scrape(adapter_name, settings, run_id))
+    except Exception:  # pragma: no cover - Celery captures the traceback
+        logger.exception("scrape-run-failed", extra={"adapter": adapter_name, "run_id": run_id})
+        raise
+    return result.model_dump()
+
+
+@celery_app.task(name="autohire.scrape.dispatch", queue=settings.scrape_queue_name)
+def dispatch_scrape_jobs() -> dict[str, Any]:
+    """Evaluate configured scrape cadences and enqueue adapter runs."""
+
+    try:
+        result = asyncio.run(dispatch_scheduled_scrapes(celery_app, settings))
+    except Exception:  # pragma: no cover - Celery captures the traceback
+        logger.exception("scrape-dispatch-failed")
+        raise
+    return result.model_dump()

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -7,3 +7,4 @@ boto3==1.34.34
 qdrant-client==1.7.0
 meilisearch==0.30.3
 python-dotenv==1.0.1
+playwright==1.41.2


### PR DESCRIPTION
## Summary
- build a Playwright-ready scraping framework in the worker with adapter registry, rate limiting, dedupe, and scheduled dispatch via Celery beat
- persist scraped jobs through new API models and ingestion endpoints that retain provenance and expose configurable scrape schedules
- add regression tests and fixtures covering ingestion, schedule updates, and environment bootstrapping for API flows

## Testing
- pytest apps/api/tests


------
https://chatgpt.com/codex/tasks/task_e_68d348d75d0c832da44bd9dc68cfa097