### PR TITLE
Add automation APIs, worker tasks, and candidate UI

### DIFF
--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -1,0 +1,14 @@
+"""Pydantic models exposed by the AutoHire API."""
+
+from .automation import (  # noqa: F401
+    ApplicationLogCreate,
+    ApplicationLogEntry,
+    AutoApplyRule,
+    AutoApplyRuleCreate,
+    AutoApplyRuleUpdate,
+    AutomationStep,
+    ResumeTemplate,
+    ResumeTemplateCreate,
+    ResumeTemplateUpdate,
+    TemplateSection,
+)

--- a/apps/api/app/models/automation.py
+++ b/apps/api/app/models/automation.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TemplateSection(BaseModel):
+    """Structured block of text for resume sections."""
+
+    title: str = Field(..., description="Section heading displayed on the resume")
+    content: str = Field(..., description="Content template supporting {{placeholders}}")
+
+
+class ResumeTemplateBase(BaseModel):
+    name: str = Field(..., description="Human friendly template name")
+    description: str = Field(..., description="Short summary explaining when to use the template")
+    sections: list[TemplateSection] = Field(
+        default_factory=list,
+        description="Ordered set of sections used for resume generation",
+    )
+    variables: list[str] = Field(
+        default_factory=list,
+        description="List of supported template variables surfaced to the UI",
+    )
+    cover_letter_template: str | None = Field(
+        default=None,
+        description="Optional cover letter body associated with this template",
+    )
+
+
+class ResumeTemplate(ResumeTemplateBase):
+    id: str = Field(..., description="Template identifier")
+
+
+class ResumeTemplateCreate(ResumeTemplateBase):
+    """Payload used when authoring a new resume template."""
+
+
+class ResumeTemplateUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    sections: list[TemplateSection] | None = None
+    variables: list[str] | None = None
+    cover_letter_template: str | None = None
+
+
+class AutoApplyRuleBase(BaseModel):
+    name: str = Field(..., description="Rule display name")
+    target_role: str = Field(..., description="Primary role the rule optimizes for")
+    keywords: list[str] = Field(default_factory=list, description="Keywords that should appear in the job description")
+    locations: list[str] = Field(default_factory=list, description="Preferred locations for the opportunity")
+    resume_template_id: str | None = Field(
+        default=None,
+        description="Optional resume template to render when the rule executes",
+    )
+    cover_letter_template_id: str | None = Field(
+        default=None,
+        description="Optional cover letter template to render when the rule executes",
+    )
+    status: Literal["active", "paused"] = Field(
+        default="active",
+        description="Whether the rule is eligible to run",
+    )
+
+
+class AutoApplyRule(AutoApplyRuleBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+    last_run_at: datetime | None = None
+
+
+class AutoApplyRuleCreate(AutoApplyRuleBase):
+    """Payload for creating an automation rule."""
+
+
+class AutoApplyRuleUpdate(BaseModel):
+    name: str | None = None
+    target_role: str | None = None
+    keywords: list[str] | None = None
+    locations: list[str] | None = None
+    resume_template_id: str | None = None
+    cover_letter_template_id: str | None = None
+    status: Literal["active", "paused"] | None = None
+    last_run_at: datetime | None = None
+
+
+class AutomationStep(BaseModel):
+    """Granular audit step recorded during automation execution."""
+
+    name: str
+    status: Literal["pending", "running", "completed", "failed"]
+    timestamp: datetime
+    detail: str | None = None
+
+
+class ApplicationLogEntry(BaseModel):
+    id: str
+    rule_id: str | None = Field(
+        default=None,
+        description="Rule that triggered the application run, if applicable",
+    )
+    job_id: str = Field(..., description="Unique job identifier used by downstream systems")
+    job_title: str = Field(..., description="Title of the job that was processed")
+    company: str = Field(..., description="Company associated with the job posting")
+    channel: Literal["native", "playwright"] = Field(
+        ..., description="Whether a first-party or scripted flow handled submission"
+    )
+    status: Literal["submitted", "failed", "skipped"]
+    submitted_at: datetime
+    audit_trail: list[AutomationStep] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class ApplicationLogCreate(BaseModel):
+    rule_id: str | None = None
+    job_id: str
+    job_title: str
+    company: str
+    channel: Literal["native", "playwright"]
+    status: Literal["submitted", "failed", "skipped"] = "submitted"
+    audit_trail: list[AutomationStep] = Field(default_factory=list)
+    notes: str | None = None
+    submitted_at: datetime | None = None

--- a/apps/api/app/routes/__init__.py
+++ b/apps/api/app/routes/__init__.py
@@ -1,7 +1,10 @@
 from fastapi import APIRouter
 
-from . import candidates, jobs
+from . import application_logs, auto_apply_rules, candidates, jobs, resume_templates
 
 api_router = APIRouter()
 api_router.include_router(candidates.router, prefix="/candidates", tags=["candidates"])
 api_router.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
+api_router.include_router(resume_templates.router, prefix="/resume-templates", tags=["resume templates"])
+api_router.include_router(auto_apply_rules.router, prefix="/auto-apply-rules", tags=["auto apply rules"])
+api_router.include_router(application_logs.router, prefix="/application-logs", tags=["application logs"])

--- a/apps/api/app/routes/application_logs.py
+++ b/apps/api/app/routes/application_logs.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Response, status
+
+from ..models.automation import ApplicationLogCreate, ApplicationLogEntry, AutomationStep
+
+router = APIRouter()
+
+
+def _seed_logs() -> list[ApplicationLogEntry]:
+    now = datetime.now(timezone.utc)
+    earlier = now - timedelta(hours=6)
+    return [
+        ApplicationLogEntry(
+            id="log-native-success",
+            rule_id="design-remote",
+            job_id="job-4231",
+            job_title="Senior Product Designer",
+            company="Canvas Labs",
+            channel="native",
+            status="submitted",
+            submitted_at=earlier,
+            audit_trail=[
+                AutomationStep(
+                    name="render_resume",
+                    status="completed",
+                    timestamp=earlier - timedelta(minutes=3),
+                    detail="Rendered product-story template",
+                ),
+                AutomationStep(
+                    name="render_cover_letter",
+                    status="completed",
+                    timestamp=earlier - timedelta(minutes=2),
+                    detail="Generated cover letter with personalization",
+                ),
+                AutomationStep(
+                    name="submit_native_application",
+                    status="completed",
+                    timestamp=earlier,
+                    detail="Submitted via ATS API",
+                ),
+            ],
+            notes="Resume and cover letter uploaded. Awaiting recruiter review.",
+        ),
+        ApplicationLogEntry(
+            id="log-playwright-failure",
+            rule_id="growth-marketing",
+            job_id="job-9654",
+            job_title="Lifecycle Marketing Manager",
+            company="Velocity Labs",
+            channel="playwright",
+            status="failed",
+            submitted_at=now - timedelta(hours=2),
+            audit_trail=[
+                AutomationStep(
+                    name="launch_browser",
+                    status="completed",
+                    timestamp=now - timedelta(hours=2, minutes=5),
+                    detail="Started Chromium via Playwright",
+                ),
+                AutomationStep(
+                    name="fill_application_form",
+                    status="failed",
+                    timestamp=now - timedelta(hours=2),
+                    detail="Captcha challenge blocked automation",
+                ),
+            ],
+            notes="Manual follow-up recommended due to captcha interruption.",
+        ),
+    ]
+
+
+_logs_store: dict[str, ApplicationLogEntry] = {log.id: log for log in _seed_logs()}
+
+
+@router.get("", response_model=list[ApplicationLogEntry])
+async def list_application_logs(rule_id: str | None = None) -> list[ApplicationLogEntry]:
+    """Return application runs, optionally scoped to a rule."""
+
+    if not rule_id:
+        return sorted(_logs_store.values(), key=lambda entry: entry.submitted_at, reverse=True)
+
+    filtered = [log for log in _logs_store.values() if log.rule_id == rule_id]
+    return sorted(filtered, key=lambda entry: entry.submitted_at, reverse=True)
+
+
+@router.get("/{log_id}", response_model=ApplicationLogEntry)
+async def get_application_log(log_id: str) -> ApplicationLogEntry:
+    log = _logs_store.get(log_id)
+    if not log:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Log entry not found")
+    return log
+
+
+@router.post("", response_model=ApplicationLogEntry, status_code=status.HTTP_201_CREATED)
+async def create_application_log(payload: ApplicationLogCreate) -> ApplicationLogEntry:
+    log_id = str(uuid4())
+    submitted_at = payload.submitted_at or datetime.now(timezone.utc)
+    log = ApplicationLogEntry(id=log_id, submitted_at=submitted_at, **payload.model_dump(exclude={"submitted_at"}))
+    _logs_store[log_id] = log
+    return log
+
+
+@router.delete("/{log_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_application_log(log_id: str) -> Response:
+    if log_id not in _logs_store:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Log entry not found")
+
+    del _logs_store[log_id]
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/app/routes/auto_apply_rules.py
+++ b/apps/api/app/routes/auto_apply_rules.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Response, status
+
+from ..models.automation import AutoApplyRule, AutoApplyRuleCreate, AutoApplyRuleUpdate
+
+router = APIRouter()
+
+
+def _seed_rules() -> list[AutoApplyRule]:
+    now = datetime.now(timezone.utc)
+    return [
+        AutoApplyRule(
+            id="design-remote",
+            name="Remote Product Design Roles",
+            target_role="Senior Product Designer",
+            keywords=["Figma", "design system", "user research"],
+            locations=["Remote", "United States"],
+            resume_template_id="product-story",
+            cover_letter_template_id="product-story",
+            status="active",
+            created_at=now,
+            updated_at=now,
+            last_run_at=None,
+        ),
+        AutoApplyRule(
+            id="growth-marketing",
+            name="Lifecycle & Growth Marketing",
+            target_role="Lifecycle Marketing Manager",
+            keywords=["experiment", "activation", "retention"],
+            locations=["Hybrid", "San Francisco", "Remote"],
+            resume_template_id="growth-optimizer",
+            cover_letter_template_id="growth-optimizer",
+            status="paused",
+            created_at=now,
+            updated_at=now,
+            last_run_at=now,
+        ),
+    ]
+
+
+_rules_store: dict[str, AutoApplyRule] = {rule.id: rule for rule in _seed_rules()}
+
+
+@router.get("", response_model=list[AutoApplyRule])
+async def list_auto_apply_rules() -> list[AutoApplyRule]:
+    """Return defined automation rules."""
+
+    return list(_rules_store.values())
+
+
+@router.get("/{rule_id}", response_model=AutoApplyRule)
+async def get_auto_apply_rule(rule_id: str) -> AutoApplyRule:
+    rule = _rules_store.get(rule_id)
+    if not rule:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+    return rule
+
+
+@router.post("", response_model=AutoApplyRule, status_code=status.HTTP_201_CREATED)
+async def create_auto_apply_rule(payload: AutoApplyRuleCreate) -> AutoApplyRule:
+    now = datetime.now(timezone.utc)
+    rule_id = str(uuid4())
+    data = payload.model_dump()
+    rule = AutoApplyRule(id=rule_id, created_at=now, updated_at=now, last_run_at=None, **data)
+    _rules_store[rule_id] = rule
+    return rule
+
+
+@router.put("/{rule_id}", response_model=AutoApplyRule)
+async def update_auto_apply_rule(rule_id: str, payload: AutoApplyRuleUpdate) -> AutoApplyRule:
+    existing = _rules_store.get(rule_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+
+    update_data = payload.model_dump(exclude_unset=True)
+    base = existing.model_dump()
+    base.update(update_data)
+    base["updated_at"] = datetime.now(timezone.utc)
+    rule = AutoApplyRule(**base)
+    _rules_store[rule_id] = rule
+    return rule
+
+
+@router.delete("/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_auto_apply_rule(rule_id: str) -> Response:
+    if rule_id not in _rules_store:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+
+    del _rules_store[rule_id]
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/app/routes/resume_templates.py
+++ b/apps/api/app/routes/resume_templates.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Response, status
+
+from ..models.automation import (
+    ResumeTemplate,
+    ResumeTemplateCreate,
+    ResumeTemplateUpdate,
+    TemplateSection,
+)
+
+router = APIRouter()
+
+
+def _seed_templates() -> list[ResumeTemplate]:
+    """Initial templates to help the frontend prototype interactions."""
+
+    return [
+        ResumeTemplate(
+            id="product-story",
+            name="Product Story Narrative",
+            description="Balanced resume that highlights storytelling, research, and impact for product design roles.",
+            sections=[
+                TemplateSection(
+                    title="Professional Summary",
+                    content=(
+                        "{{candidate.name}} is a {{candidate.yearsExperience}}-year {{candidate.title}} who "
+                        "ships lovable experiences by pairing strategy with craft. Ready to support {{job.company}} as a "
+                        "{{job.title}} with a bias for experimentation and measurable outcomes."
+                    ),
+                ),
+                TemplateSection(
+                    title="Core Strengths",
+                    content=(
+                        "Key tools and rituals: {{skills}}."
+                    ),
+                ),
+                TemplateSection(
+                    title="Recent Impact",
+                    content=(
+                        "Signature wins:\n{{achievements}}"
+                    ),
+                ),
+            ],
+            variables=[
+                "candidate.name",
+                "candidate.title",
+                "candidate.yearsExperience",
+                "job.company",
+                "job.title",
+                "skills",
+                "achievements",
+            ],
+            cover_letter_template=(
+                "Hello {{job.company}} team,\n\n"
+                "I'm energized by the {{job.title}} opening and the opportunity to blend research, strategy, and craft to "
+                "deliver measurable product wins. {{candidate.name}}"
+            ),
+        ),
+        ResumeTemplate(
+            id="growth-optimizer",
+            name="Growth Optimizer",
+            description="Data-forward resume tuned for experimentation and lifecycle marketing roles.",
+            sections=[
+                TemplateSection(
+                    title="Mission Statement",
+                    content=(
+                        "Growth leader with {{candidate.yearsExperience}} years refining the full funnel. Specialized in "
+                        "activation, retention, and monetization for SaaS and marketplace products."
+                    ),
+                ),
+                TemplateSection(
+                    title="Experiments That Moved Metrics",
+                    content="Highlights:\n{{achievements}}",
+                ),
+                TemplateSection(
+                    title="Toolkit",
+                    content="Stacks mastered: {{skills}}.",
+                ),
+            ],
+            variables=[
+                "candidate.yearsExperience",
+                "achievements",
+                "skills",
+            ],
+            cover_letter_template=(
+                "Hi there,\n\n"
+                "The experimentation culture at {{job.company}} caught my eye. I'm eager to bring a hypothesis-driven mindset "
+                "and a knack for cross-functional facilitation to the {{job.title}} role."
+            ),
+        ),
+    ]
+
+
+_templates_store: dict[str, ResumeTemplate] = {template.id: template for template in _seed_templates()}
+
+
+@router.get("", response_model=list[ResumeTemplate])
+async def list_resume_templates() -> list[ResumeTemplate]:
+    """Return all resume templates."""
+
+    return list(_templates_store.values())
+
+
+@router.get("/{template_id}", response_model=ResumeTemplate)
+async def get_resume_template(template_id: str) -> ResumeTemplate:
+    """Retrieve a single template."""
+
+    template = _templates_store.get(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return template
+
+
+@router.post("", response_model=ResumeTemplate, status_code=status.HTTP_201_CREATED)
+async def create_resume_template(payload: ResumeTemplateCreate) -> ResumeTemplate:
+    """Create a new in-memory template."""
+
+    template_id = str(uuid4())
+    template = ResumeTemplate(id=template_id, **payload.model_dump())
+    _templates_store[template_id] = template
+    return template
+
+
+@router.put("/{template_id}", response_model=ResumeTemplate)
+async def update_resume_template(template_id: str, payload: ResumeTemplateUpdate) -> ResumeTemplate:
+    """Update an existing template."""
+
+    existing = _templates_store.get(template_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+
+    update_data = payload.model_dump(exclude_unset=True)
+    data = existing.model_dump()
+    data.update(update_data)
+    template = ResumeTemplate(**data)
+    _templates_store[template_id] = template
+    return template
+
+
+@router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_resume_template(template_id: str) -> Response:
+    """Remove a template from the in-memory store."""
+
+    if template_id not in _templates_store:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+
+    del _templates_store[template_id]
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/candidate-portal/.eslintrc.json
+++ b/apps/candidate-portal/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/apps/candidate-portal/app/globals.css
+++ b/apps/candidate-portal/app/globals.css
@@ -19,3 +19,318 @@ a {
 * {
   box-sizing: border-box;
 }
+
+main.page {
+  padding: 3.5rem 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page__header {
+  text-align: left;
+  margin-bottom: 2.5rem;
+}
+
+.page__header h1 {
+  margin: 0 0 0.75rem;
+  font-size: 2.5rem;
+  color: #1e1b4b;
+}
+
+.page__header p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: #334155;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  margin-bottom: 2rem;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #dbeafe;
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(8px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  color: #1d4ed8;
+}
+
+.template-meta {
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 1.1rem;
+}
+
+.field-group label,
+label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  color: #1e3a8a;
+}
+
+.field-group input,
+.field-group select,
+.rule-filter,
+.field-group textarea {
+  border: 1px solid #cbd5f5;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: #f8fbff;
+  color: #0f172a;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.field-group input:focus,
+.field-group select:focus,
+.rule-filter:focus,
+.field-group textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.resume-variables {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.section-preview {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #ffffff;
+  margin-bottom: 1rem;
+}
+
+.section-preview h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  color: #1d4ed8;
+}
+
+.text-block {
+  white-space: pre-line;
+  line-height: 1.6;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.cover-letter-preview {
+  border: 1px dashed #cbd5f5;
+  border-radius: 12px;
+  padding: 1.1rem;
+  background: #fdf4ff;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.button {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button--primary {
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+}
+
+.button--ghost {
+  background: transparent;
+  color: #4f46e5;
+  border: 1px solid rgba(79, 70, 229, 0.35);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(99, 102, 241, 0.18);
+}
+
+.rule-card {
+  border: 1px solid #dbeafe;
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+  background: #f8fbff;
+  margin-bottom: 1rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.06);
+}
+
+.rule-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.rule-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #1f2937;
+}
+
+.rule-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: #475569;
+  margin: 0.5rem 0;
+}
+
+.rule-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  background: #ede9fe;
+  color: #5b21b6;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.status-pill--active {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.status-pill--paused {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-pill--submitted {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-pill--failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-pill--skipped {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.logs-grid {
+  display: grid;
+  gap: 1.1rem;
+  margin-top: 1.2rem;
+}
+
+.log-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.07);
+}
+
+.log-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.log-card__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.audit-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+}
+
+.audit-steps li {
+  position: relative;
+  padding: 0.45rem 0 0.45rem 0.85rem;
+  border-left: 2px solid #e2e8f0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.audit-steps li::before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 12px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #6366f1;
+}
+
+.audit-steps strong {
+  display: block;
+  color: #1f2937;
+  font-size: 0.85rem;
+  margin-bottom: 0.2rem;
+}

--- a/apps/candidate-portal/app/page.tsx
+++ b/apps/candidate-portal/app/page.tsx
@@ -1,21 +1,646 @@
-export default function HomePage() {
+"use client";
+
+import type { ChangeEvent, FormEvent } from "react";
+import { useMemo, useState } from "react";
+
+type TemplateSection = {
+  title: string;
+  content: string;
+};
+
+type ResumeTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  sections: TemplateSection[];
+  variables: string[];
+  coverLetterTemplate?: string | null;
+};
+
+type AutoApplyRule = {
+  id: string;
+  name: string;
+  targetRole: string;
+  keywords: string[];
+  locations: string[];
+  resumeTemplateId: string | null;
+  coverLetterTemplateId: string | null;
+  status: "active" | "paused";
+};
+
+type AutomationStep = {
+  name: string;
+  status: "pending" | "running" | "completed" | "failed";
+  timestamp: string;
+  detail?: string;
+};
+
+type AutomationLog = {
+  id: string;
+  ruleId: string | null;
+  jobId: string;
+  jobTitle: string;
+  company: string;
+  channel: "native" | "playwright";
+  status: "submitted" | "failed" | "skipped";
+  submittedAt: string;
+  auditTrail: AutomationStep[];
+  notes?: string;
+};
+
+type CandidateProfile = {
+  candidate: {
+    name: string;
+    title: string;
+    yearsExperience: number;
+    email: string;
+    summary: string;
+  };
+  skills: string[];
+  achievements: string[];
+};
+
+type JobFormState = {
+  title: string;
+  company: string;
+  location: string;
+};
+
+type RuleFormState = {
+  name: string;
+  targetRole: string;
+  keywords: string;
+  locations: string;
+  resumeTemplateId: string;
+  coverLetterTemplateId: string;
+};
+
+const candidateProfile: CandidateProfile = {
+  candidate: {
+    name: "Jordan Rivers",
+    title: "Product Designer",
+    yearsExperience: 8,
+    email: "jordan.rivers@autohire.app",
+    summary:
+      "Product storyteller blending research, systems thinking, and prototyping to ship lovable multi-platform experiences.",
+  },
+  skills: [
+    "Design systems leadership",
+    "Mixed-method research",
+    "Rapid prototyping",
+    "Journey orchestration",
+  ],
+  achievements: [
+    "Grew trial-to-paid conversion by 28% by redesigning onboarding flows with experimentation across 3 cohorts.",
+    "Scaled a modular design system that accelerated shipping velocity across 6 cross-functional squads.",
+    "Reduced support volume by 35% by launching proactive education and simplifying workflows.",
+  ],
+};
+
+const resumeTemplates: ResumeTemplate[] = [
+  {
+    id: "product-story",
+    name: "Product Story Narrative",
+    description:
+      "Balanced resume that highlights storytelling, research, and impact for product design roles.",
+    sections: [
+      {
+        title: "Professional Summary",
+        content:
+          "{{candidate.name}} is a {{candidate.yearsExperience}}-year {{candidate.title}} who ships lovable experiences by pairing strategy with craft. Ready to support {{job.company}} as a {{job.title}} with a bias for experimentation and measurable outcomes.",
+      },
+      {
+        title: "Core Strengths",
+        content: "Key tools and rituals: {{skills}}.",
+      },
+      {
+        title: "Recent Impact",
+        content: "Signature wins:\n{{achievements}}",
+      },
+    ],
+    variables: [
+      "candidate.name",
+      "candidate.title",
+      "candidate.yearsExperience",
+      "job.company",
+      "job.title",
+      "skills",
+      "achievements",
+    ],
+    coverLetterTemplate:
+      "Hello {{job.company}} team,\n\nI'm energized by the {{job.title}} opening and the opportunity to blend research, strategy, and craft to deliver measurable product wins. {{candidate.name}}",
+  },
+  {
+    id: "growth-optimizer",
+    name: "Growth Optimizer",
+    description: "Data-forward resume tuned for experimentation and lifecycle marketing roles.",
+    sections: [
+      {
+        title: "Mission Statement",
+        content:
+          "Growth leader with {{candidate.yearsExperience}} years refining the full funnel. Specialized in activation, retention, and monetization for SaaS and marketplace products.",
+      },
+      {
+        title: "Experiments That Moved Metrics",
+        content: "Highlights:\n{{achievements}}",
+      },
+      {
+        title: "Toolkit",
+        content: "Stacks mastered: {{skills}}.",
+      },
+    ],
+    variables: ["candidate.yearsExperience", "achievements", "skills"],
+    coverLetterTemplate:
+      "Hi there,\n\nThe experimentation culture at {{job.company}} caught my eye. I'm eager to bring a hypothesis-driven mindset and a knack for cross-functional facilitation to the {{job.title}} role.",
+  },
+];
+
+const initialRules: AutoApplyRule[] = [
+  {
+    id: "design-remote",
+    name: "Remote Product Design Roles",
+    targetRole: "Senior Product Designer",
+    keywords: ["Figma", "design system", "user research"],
+    locations: ["Remote", "United States"],
+    resumeTemplateId: "product-story",
+    coverLetterTemplateId: "product-story",
+    status: "active",
+  },
+  {
+    id: "growth-marketing",
+    name: "Lifecycle & Growth Marketing",
+    targetRole: "Lifecycle Marketing Manager",
+    keywords: ["experiment", "activation", "retention"],
+    locations: ["Hybrid", "San Francisco", "Remote"],
+    resumeTemplateId: "growth-optimizer",
+    coverLetterTemplateId: "growth-optimizer",
+    status: "paused",
+  },
+];
+
+const seededAutomationLogs: AutomationLog[] = [
+  {
+    id: "log-native-success",
+    ruleId: "design-remote",
+    jobId: "job-4231",
+    jobTitle: "Senior Product Designer",
+    company: "Canvas Labs",
+    channel: "native",
+    status: "submitted",
+    submittedAt: "2024-05-01T17:22:00.000Z",
+    auditTrail: [
+      {
+        name: "render_resume",
+        status: "completed",
+        timestamp: "2024-05-01T17:19:00.000Z",
+        detail: "Rendered product-story template",
+      },
+      {
+        name: "render_cover_letter",
+        status: "completed",
+        timestamp: "2024-05-01T17:20:30.000Z",
+        detail: "Generated cover letter with personalization",
+      },
+      {
+        name: "submit_native_application",
+        status: "completed",
+        timestamp: "2024-05-01T17:22:00.000Z",
+        detail: "Submitted via ATS API",
+      },
+    ],
+    notes: "Resume and cover letter uploaded. Awaiting recruiter review.",
+  },
+  {
+    id: "log-playwright-failure",
+    ruleId: "growth-marketing",
+    jobId: "job-9654",
+    jobTitle: "Lifecycle Marketing Manager",
+    company: "Velocity Labs",
+    channel: "playwright",
+    status: "failed",
+    submittedAt: "2024-05-02T19:12:00.000Z",
+    auditTrail: [
+      {
+        name: "launch_browser",
+        status: "completed",
+        timestamp: "2024-05-02T19:07:00.000Z",
+        detail: "Started Chromium via Playwright",
+      },
+      {
+        name: "fill_application_form",
+        status: "failed",
+        timestamp: "2024-05-02T19:12:00.000Z",
+        detail: "Captcha challenge blocked automation",
+      },
+    ],
+    notes: "Manual follow-up recommended due to captcha interruption.",
+  },
+];
+
+const PLACEHOLDER_PATTERN = /{{\s*([\w.]+)\s*}}/g;
+
+function resolvePlaceholder(context: Record<string, unknown>, path: string): unknown {
+  const segments = path.split(".");
+  let current: unknown = context;
+  for (const segment of segments) {
+    if (typeof current !== "object" || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => `• ${item}`).join("\n");
+  }
+  return String(value);
+}
+
+function renderText(template: string, context: Record<string, unknown>): string {
+  return template.replace(PLACEHOLDER_PATTERN, (_, key) => formatValue(resolvePlaceholder(context, key)));
+}
+
+function formatDate(isoDate: string): string {
+  const parsed = new Date(isoDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return isoDate;
+  }
+  return parsed.toLocaleString();
+}
+
+function statusClass(base: string): string {
+  return `status-pill status-pill--${base}`;
+}
+
+export default function AutomationWorkspacePage() {
+  const [selectedTemplateId, setSelectedTemplateId] = useState(resumeTemplates[0]?.id ?? "");
+  const [jobForm, setJobForm] = useState<JobFormState>({
+    title: "Senior Product Designer",
+    company: "Canvas Labs",
+    location: "Remote - North America",
+  });
+  const [rules, setRules] = useState<AutoApplyRule[]>(initialRules);
+  const [ruleForm, setRuleForm] = useState<RuleFormState>({
+    name: "",
+    targetRole: "",
+    keywords: "",
+    locations: "",
+    resumeTemplateId: resumeTemplates[0]?.id ?? "",
+    coverLetterTemplateId: resumeTemplates[0]?.id ?? "",
+  });
+  const [logs] = useState<AutomationLog[]>(seededAutomationLogs);
+  const [logFilter, setLogFilter] = useState<string>("all");
+
+  const activeTemplate = useMemo(
+    () => resumeTemplates.find((template) => template.id === selectedTemplateId) ?? null,
+    [selectedTemplateId],
+  );
+
+  const previewContext = useMemo(() => ({
+    ...candidateProfile,
+    job: { ...jobForm },
+  }), [jobForm]);
+
+  const resumePreview = useMemo(() => {
+    if (!activeTemplate) {
+      return [];
+    }
+    return activeTemplate.sections.map((section) => ({
+      title: section.title,
+      content: renderText(section.content, previewContext as Record<string, unknown>),
+    }));
+  }, [activeTemplate, previewContext]);
+
+  const coverLetterPreview = useMemo(() => {
+    if (!activeTemplate) {
+      return "";
+    }
+    const body = activeTemplate.coverLetterTemplate ??
+      "Hello {{job.company}} team,\n\nI'm excited about the opportunity to contribute to {{job.title}}.";
+    return renderText(body, previewContext as Record<string, unknown>);
+  }, [activeTemplate, previewContext]);
+
+  const filteredLogs = useMemo(() => {
+    if (logFilter === "all") {
+      return logs;
+    }
+    return logs.filter((log) => log.ruleId === logFilter);
+  }, [logFilter, logs]);
+
+  const handleJobChange = (field: keyof JobFormState) => (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setJobForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const handleRuleFieldChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = event.target;
+    setRuleForm((previous) => ({ ...previous, [name]: value }));
+  };
+
+  const handleCreateRule = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!ruleForm.name || !ruleForm.targetRole) {
+      return;
+    }
+
+    const keywords = ruleForm.keywords
+      .split(",")
+      .map((keyword) => keyword.trim())
+      .filter(Boolean);
+    const locations = ruleForm.locations
+      .split(",")
+      .map((location) => location.trim())
+      .filter(Boolean);
+
+    setRules((previous) => [
+      ...previous,
+      {
+        id: `draft-${Date.now()}`,
+        name: ruleForm.name,
+        targetRole: ruleForm.targetRole,
+        keywords,
+        locations,
+        resumeTemplateId: ruleForm.resumeTemplateId,
+        coverLetterTemplateId: ruleForm.coverLetterTemplateId,
+        status: "active",
+      },
+    ]);
+
+    setRuleForm((previous) => ({
+      ...previous,
+      name: "",
+      targetRole: "",
+      keywords: "",
+      locations: "",
+    }));
+  };
+
+  const handleToggleRule = (ruleId: string) => {
+    setRules((previous) =>
+      previous.map((rule) =>
+        rule.id === ruleId ? { ...rule, status: rule.status === "active" ? "paused" : "active" } : rule,
+      ),
+    );
+  };
+
   return (
-    <main style={{ padding: "4rem", maxWidth: "960px", margin: "0 auto" }}>
-      <h1>AutoHire Candidate Portal</h1>
-      <p>
-        This is the placeholder experience for the candidate-facing application. It
-        will eventually surface onboarding, profile management, job discovery, microtasks,
-        and automation controls.
-      </p>
-      <ul>
-        <li>Onboarding wizard with resume parsing</li>
-        <li>Job and microtask discovery with hybrid search</li>
-        <li>Auto-apply rules and resume improvement workflows</li>
-      </ul>
-      <p>
-        Refer to the documentation in <code>docs/</code> for the comprehensive
-        specification and acceptance criteria.
-      </p>
+    <main className="page">
+      <header className="page__header">
+        <h1>Automation Workspace</h1>
+        <p>
+          Configure tailored resume templates, rule-driven auto-apply workflows, and monitor automation performance from a
+          single control surface.
+        </p>
+      </header>
+
+      <section className="grid">
+        <div className="panel">
+          <h2>Target role context</h2>
+          <p className="template-meta">
+            Update the job details to instantly preview how personalized content adapts across templates.
+          </p>
+          <div className="field-group">
+            <label htmlFor="job-title">Job title</label>
+            <input id="job-title" value={jobForm.title} onChange={handleJobChange("title")} placeholder="Senior Product Designer" />
+          </div>
+          <div className="field-group">
+            <label htmlFor="job-company">Company</label>
+            <input id="job-company" value={jobForm.company} onChange={handleJobChange("company")} placeholder="Canvas Labs" />
+          </div>
+          <div className="field-group">
+            <label htmlFor="job-location">Location</label>
+            <input id="job-location" value={jobForm.location} onChange={handleJobChange("location")} placeholder="Remote" />
+          </div>
+
+          <div className="field-group">
+            <label htmlFor="template-select">Resume template</label>
+            <select
+              id="template-select"
+              value={selectedTemplateId}
+              onChange={(event) => setSelectedTemplateId(event.target.value)}
+            >
+              {resumeTemplates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {activeTemplate ? <p className="template-meta">{activeTemplate.description}</p> : null}
+          {activeTemplate ? (
+            <div className="resume-variables">
+              {activeTemplate.variables.map((variable) => (
+                <span key={variable} className="badge">
+                  {variable}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="panel">
+          <h2>Preview</h2>
+          {resumePreview.map((section) => (
+            <div key={section.title} className="section-preview">
+              <h3>{section.title}</h3>
+              <p className="text-block">{section.content}</p>
+            </div>
+          ))}
+
+          <div className="cover-letter-preview">
+            <h3>Cover letter draft</h3>
+            <p className="text-block">{coverLetterPreview}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="panel">
+        <h2>Auto-apply rules</h2>
+        <p className="template-meta">
+          Prioritize which combinations of keywords, locations, and templates should trigger automated submissions.
+        </p>
+        <form onSubmit={handleCreateRule}>
+          <div className="field-group">
+            <label htmlFor="rule-name">Rule name</label>
+            <input
+              id="rule-name"
+              name="name"
+              value={ruleForm.name}
+              onChange={handleRuleFieldChange}
+              placeholder="North America design leadership"
+            />
+          </div>
+          <div className="field-group">
+            <label htmlFor="rule-role">Target role</label>
+            <input
+              id="rule-role"
+              name="targetRole"
+              value={ruleForm.targetRole}
+              onChange={handleRuleFieldChange}
+              placeholder="Principal Product Designer"
+            />
+          </div>
+          <div className="field-group">
+            <label htmlFor="rule-keywords">Must have keywords</label>
+            <input
+              id="rule-keywords"
+              name="keywords"
+              value={ruleForm.keywords}
+              onChange={handleRuleFieldChange}
+              placeholder="design system, experimentation"
+            />
+          </div>
+          <div className="field-group">
+            <label htmlFor="rule-locations">Preferred locations</label>
+            <input
+              id="rule-locations"
+              name="locations"
+              value={ruleForm.locations}
+              onChange={handleRuleFieldChange}
+              placeholder="Remote, Portland"
+            />
+          </div>
+          <div className="field-group">
+            <label htmlFor="rule-resume-template">Resume template</label>
+            <select
+              id="rule-resume-template"
+              name="resumeTemplateId"
+              value={ruleForm.resumeTemplateId}
+              onChange={handleRuleFieldChange}
+            >
+              {resumeTemplates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field-group">
+            <label htmlFor="rule-cover-template">Cover letter template</label>
+            <select
+              id="rule-cover-template"
+              name="coverLetterTemplateId"
+              value={ruleForm.coverLetterTemplateId}
+              onChange={handleRuleFieldChange}
+            >
+              {resumeTemplates.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="form-actions">
+            <button type="submit" className="button button--primary">
+              Save rule
+            </button>
+          </div>
+        </form>
+
+        <div>
+          {rules.map((rule) => (
+            <div key={rule.id} className="rule-card">
+              <div className="rule-card__header">
+                <div>
+                  <h3>{rule.name}</h3>
+                  <p className="rule-card__meta">Optimizes for {rule.targetRole}</p>
+                </div>
+                <div className={statusClass(rule.status)}>{rule.status}</div>
+              </div>
+              <div className="rule-card__meta">
+                <span>Keywords:</span>
+                <div className="rule-card__chips">
+                  {rule.keywords.map((keyword) => (
+                    <span key={keyword} className="tag">
+                      {keyword}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="rule-card__meta">
+                <span>Locations:</span>
+                <div className="rule-card__chips">
+                  {rule.locations.map((location) => (
+                    <span key={location} className="tag">
+                      {location}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="rule-card__meta">
+                <span>Resume:</span> {rule.resumeTemplateId || "Manual selection"}
+              </div>
+              <div className="rule-card__meta">
+                <span>Cover letter:</span> {rule.coverLetterTemplateId || "Manual selection"}
+              </div>
+              <div className="form-actions">
+                <button type="button" className="button button--ghost" onClick={() => handleToggleRule(rule.id)}>
+                  {rule.status === "active" ? "Pause" : "Activate"}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel">
+        <h2>Automation activity</h2>
+        <p className="template-meta">
+          Inspect each submission attempt across native integrations and Playwright-powered browser runs.
+        </p>
+        <label htmlFor="log-filter">Filter by rule</label>
+        <select
+          id="log-filter"
+          className="rule-filter"
+          value={logFilter}
+          onChange={(event) => setLogFilter(event.target.value)}
+        >
+          <option value="all">All runs</option>
+          {rules.map((rule) => (
+            <option key={rule.id} value={rule.id}>
+              {rule.name}
+            </option>
+          ))}
+        </select>
+
+        <div className="logs-grid">
+          {filteredLogs.map((log) => (
+            <article key={log.id} className="log-card">
+              <div className="log-card__header">
+                <div>
+                  <h3>
+                    {log.jobTitle} &middot; {log.company}
+                  </h3>
+                  <p className="template-meta">Job ID: {log.jobId}</p>
+                </div>
+                <div>
+                  <div className={statusClass(log.status)}>{log.status}</div>
+                  <div className="badge" style={{ marginTop: "0.5rem" }}>
+                    {log.channel}
+                  </div>
+                </div>
+              </div>
+              <p className="template-meta">Submitted {formatDate(log.submittedAt)}</p>
+              {log.notes ? <p className="text-block">{log.notes}</p> : null}
+              <ul className="audit-steps">
+                {log.auditTrail.map((step) => (
+                  <li key={`${log.id}-${step.name}`}>
+                    <strong>{step.name}</strong>
+                    <span>{step.status}</span>
+                    {step.detail ? <span> &mdash; {step.detail}</span> : null}
+                    <div>{formatDate(step.timestamp)}</div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/apps/candidate-portal/next-env.d.ts
+++ b/apps/candidate-portal/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/candidate-portal/tsconfig.json
+++ b/apps/candidate-portal/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -11,8 +15,22 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true,
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/apps/worker/app/worker.py
+++ b/apps/worker/app/worker.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import os
+import re
+from datetime import datetime, timezone
+from typing import Any
 
 from celery import Celery
 
@@ -11,9 +14,155 @@ celery_app = Celery("autohire", broker=CELERY_BROKER_URL, backend=CELERY_BACKEND
 celery_app.conf.task_default_queue = "default"
 celery_app.conf.result_expires = 3600
 
+PLACEHOLDER_PATTERN = re.compile(r"{{\s*([\w\.]+)\s*}}")
+
+
+def _compose_context(candidate_profile: dict[str, Any], job_posting: dict[str, Any]) -> dict[str, Any]:
+    """Merge profile and job data into a single lookup dictionary for templates."""
+
+    context: dict[str, Any] = dict(candidate_profile)
+    if "candidate" not in context:
+        scalar_fields = {
+            key: value
+            for key, value in candidate_profile.items()
+            if not isinstance(value, (list, dict))
+        }
+        context["candidate"] = scalar_fields
+    context.setdefault("candidate", {})
+    context["job"] = job_posting
+    return context
+
+
+def _pluck(context: dict[str, Any], dotted_key: str) -> Any:
+    value: Any = context
+    for part in dotted_key.split("."):
+        if isinstance(value, dict):
+            value = value.get(part)
+        else:
+            return None
+    return value
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return "\n".join(f"• {item}" for item in value)
+    return str(value)
+
+
+def _render_text(template_text: str, context: dict[str, Any]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        value = _pluck(context, key)
+        return _format_value(value)
+
+    return PLACEHOLDER_PATTERN.sub(replace, template_text)
+
+
+def _audit_event(name: str, status: str, detail: str | None = None) -> dict[str, Any]:
+    return {
+        "name": name,
+        "status": status,
+        "detail": detail,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
 
 @celery_app.task(name="autohire.echo")
 def echo(message: str) -> str:
     """Simple heartbeat task for smoke testing the worker stack."""
 
     return message
+
+
+@celery_app.task(name="autohire.generate_tailored_resume")
+def generate_tailored_resume(
+    template: dict[str, Any],
+    candidate_profile: dict[str, Any],
+    job_posting: dict[str, Any],
+) -> dict[str, Any]:
+    """Render resume sections using the provided template and context."""
+
+    context = _compose_context(candidate_profile, job_posting)
+    rendered_sections = []
+    for section in template.get("sections", []):
+        rendered_sections.append(
+            {
+                "title": section.get("title", ""),
+                "content": _render_text(section.get("content", ""), context),
+            }
+        )
+
+    return {
+        "template_id": template.get("id"),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sections": rendered_sections,
+        "variables_used": template.get("variables", []),
+    }
+
+
+@celery_app.task(name="autohire.generate_cover_letter")
+def generate_cover_letter(
+    template: dict[str, Any],
+    candidate_profile: dict[str, Any],
+    job_posting: dict[str, Any],
+) -> dict[str, Any]:
+    """Produce a personalized cover letter body."""
+
+    context = _compose_context(candidate_profile, job_posting)
+    cover_letter_template = template.get("cover_letter_template") or (
+        "Hello {{job.company}} team,\n\n{{candidate.name}} is excited about the {{job.title}} opportunity."
+    )
+    body = _render_text(cover_letter_template, context)
+
+    return {
+        "template_id": template.get("id"),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "body": body,
+    }
+
+
+@celery_app.task(name="autohire.submit_application")
+def submit_application(application_payload: dict[str, Any]) -> dict[str, Any]:
+    """Simulate a native or scripted application submission with audit details."""
+
+    submission_mode = application_payload.get("submission_mode", "native")
+    job = application_payload.get("job", {})
+    candidate = application_payload.get("candidate", {})
+    rule_id = application_payload.get("rule_id")
+    audit_trail: list[dict[str, Any]] = []
+
+    audit_trail.append(_audit_event("prepare_application", "completed", "Packaged resume and cover letter"))
+
+    if submission_mode == "playwright":
+        audit_trail.append(_audit_event("launch_browser", "completed", "Booted Chromium via Playwright"))
+        if application_payload.get("simulate_failure"):
+            audit_trail.append(
+                _audit_event(
+                    "complete_web_form",
+                    "failed",
+                    "Captcha challenge requires manual follow-up",
+                )
+            )
+            status = "failed"
+            notes = "Playwright automation failed due to captcha."
+        else:
+            audit_trail.append(_audit_event("complete_web_form", "completed", "Filed job application via scripted flow"))
+            status = "submitted"
+            notes = "Application submitted using Playwright automation."
+    else:
+        audit_trail.append(_audit_event("call_native_integration", "completed", "Submitted via ATS API"))
+        status = "submitted"
+        notes = "Application submitted through native integration."
+
+    return {
+        "status": status,
+        "rule_id": rule_id,
+        "job": job,
+        "candidate": {"name": candidate.get("name"), "email": candidate.get("email")},
+        "submission_mode": submission_mode,
+        "submitted_at": datetime.now(timezone.utc).isoformat(),
+        "audit_trail": audit_trail,
+        "notes": notes,
+    }


### PR DESCRIPTION
## Summary
- add Pydantic models plus FastAPI routes for resume templates, auto-apply rules, and application logs with seeded data
- extend the Celery worker with tasks to render tailored resumes, generate cover letters, and submit applications with auditing metadata
- build a candidate-facing automation workspace UI that configures rules, previews generated documents, and reviews submission logs

## Testing
- PYTHONPATH=. pytest *(fails: Settings validation requires env secrets in this environment)*
- npm run lint *(fails: project does not yet include eslint as a dev dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d348d237fc832db0c66914b7f04f10