### PR TITLE
Add OpenCATS sync utilities and employer portal controls

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -5,23 +5,34 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    """Application configuration loaded from environment variables.
+
+    Defaults enable local development and automated tests without a
+    fully provisioned infrastructure stack. Production deployments
+    should override these values via environment variables or secrets
+    management.
+    """
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     app_env: str = "development"
-    database_url: str
-    redis_url: str
-    minio_endpoint: str
-    minio_access_key: str
-    minio_secret_key: str
-    meilisearch_url: str
-    meilisearch_api_key: str
-    qdrant_url: str
-    keycloak_url: str
-    keycloak_realm: str
-    keycloak_client_id: str
-    keycloak_client_secret: str
+    database_url: str = "postgresql+asyncpg://autohire:autohire@localhost:5432/autohire"
+    redis_url: str = "redis://localhost:6379/0"
+    minio_endpoint: str = "http://localhost:9000"
+    minio_access_key: str = "autohire"
+    minio_secret_key: str = "autohire"
+    meilisearch_url: str = "http://localhost:7700"
+    meilisearch_api_key: str = "development"
+    qdrant_url: str = "http://localhost:6333"
+    keycloak_url: str = "http://localhost:8080"
+    keycloak_realm: str = "autohire"
+    keycloak_client_id: str = "autohire"
+    keycloak_client_secret: str = "development"
+    opencats_base_url: str = "http://localhost:8081"
+    opencats_api_key: str = "development"
     posthog_api_key: str | None = None
     allowed_origins: List[str] = []
+    celery_task_eager: bool = True
 
 
 @lru_cache

--- a/apps/api/app/opencats/__init__.py
+++ b/apps/api/app/opencats/__init__.py
@@ -1,0 +1,6 @@
+"""OpenCATS integration utilities."""
+
+from .client import OpenCATSClient
+
+__all__ = ["OpenCATSClient"]
+

--- a/apps/api/app/opencats/client.py
+++ b/apps/api/app/opencats/client.py
@@ -1,0 +1,76 @@
+"""OpenCATS client helpers used by synchronization tasks."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.core.config import get_settings
+
+from . import mappers
+from .models import LocalApplicationBundle, LocalCandidate, LocalJob, LocalResume
+
+
+class OpenCATSClient:
+    """Lightweight helper producing OpenCATS payloads."""
+
+    def __init__(self, base_url: str | None = None, api_key: str | None = None) -> None:
+        settings = get_settings()
+        self.base_url = base_url or settings.opencats_base_url
+        self.api_key = api_key or settings.opencats_api_key
+
+    # ------------------------------------------------------------------
+    # Payload builders
+    # ------------------------------------------------------------------
+    def build_candidate_payload(
+        self, candidate: LocalCandidate, resume: LocalResume | None = None
+    ) -> Dict[str, Any]:
+        candidate_payload = mappers.map_candidate_to_opencats(candidate).model_dump(by_alias=True)
+        attachments: list[dict[str, Any]] = []
+        if resume is not None:
+            attachments.append(mappers.map_resume_to_opencats(resume).model_dump(by_alias=True))
+
+        return {
+            "candidate": candidate_payload,
+            "attachments": attachments,
+            "endpoint": f"{self.base_url}/candidate",
+        }
+
+    def build_job_payload(self, job: LocalJob) -> Dict[str, Any]:
+        job_payload = mappers.map_job_to_opencats(job).model_dump(by_alias=True)
+        return {
+            "joborder": job_payload,
+            "endpoint": f"{self.base_url}/joborder",
+        }
+
+    def build_application_payload(self, bundle: LocalApplicationBundle) -> Dict[str, Any]:
+        candidate = mappers.map_candidate_to_opencats(bundle.candidate).model_dump(by_alias=True)
+        job = mappers.map_job_to_opencats(bundle.job).model_dump(by_alias=True)
+        application = mappers.map_application_to_opencats(bundle).model_dump(by_alias=True)
+
+        attachments: list[dict[str, Any]] = []
+        if bundle.resume is not None:
+            attachments.append(mappers.map_resume_to_opencats(bundle.resume).model_dump(by_alias=True))
+
+        return {
+            "candidate": candidate,
+            "joborder": job,
+            "candidate_joborder": application,
+            "attachments": attachments,
+            "endpoint": f"{self.base_url}/candidate_joborder",
+        }
+
+    def build_reconcile_payload(self, scope: str, target_id: str) -> Dict[str, Any]:
+        """Return a simple payload representing a reconciliation request."""
+
+        return {
+            "scope": scope,
+            "target_id": target_id,
+            "endpoint": f"{self.base_url}/reconcile",
+        }
+
+    # ------------------------------------------------------------------
+    def build_headers(self) -> Dict[str, str]:
+        """Return authorization headers for outbound requests."""
+
+        return {"Authorization": f"Bearer {self.api_key}"}
+

--- a/apps/api/app/opencats/mappers.py
+++ b/apps/api/app/opencats/mappers.py
@@ -1,0 +1,124 @@
+"""Conversion utilities between AutoHire and OpenCATS models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from .models import (
+    ApplicationStatus,
+    LocalApplication,
+    LocalApplicationBundle,
+    LocalCandidate,
+    LocalJob,
+    LocalResume,
+    OpenCATSAttachment,
+    OpenCATSCandidate,
+    OpenCATSCandidateJobOrder,
+    OpenCATSJobOrder,
+    WorkType,
+)
+
+
+APPLICATION_STATUS_MAPPING: dict[ApplicationStatus, str] = {
+    ApplicationStatus.NEW: "New Lead",
+    ApplicationStatus.SCREEN: "Screen",
+    ApplicationStatus.INTERVIEW: "Interview",
+    ApplicationStatus.OFFER: "Offer",
+    ApplicationStatus.HIRED: "Hired",
+    ApplicationStatus.REJECTED: "Rejected",
+}
+
+
+def _currency_from_cents(value: int | None) -> float | None:
+    if value is None:
+        return None
+    return round(value / 100, 2)
+
+
+def _normalize_skills(skills: Iterable[str]) -> str | None:
+    unique = sorted({skill.strip().title() for skill in skills if skill.strip()})
+    if not unique:
+        return None
+    return ", ".join(unique)
+
+
+def _format_work_type(work_type: WorkType | None) -> str | None:
+    if work_type is None:
+        return None
+    return work_type.value.replace("_", " ").title()
+
+
+def map_candidate_to_opencats(candidate: LocalCandidate) -> OpenCATSCandidate:
+    """Convert an AutoHire candidate to an OpenCATS candidate payload."""
+
+    return OpenCATSCandidate(
+        candidate_id=candidate.id,
+        first_name=candidate.first_name,
+        last_name=candidate.last_name,
+        email1=candidate.email,
+        phone1=candidate.phone,
+        city=candidate.city,
+        country=candidate.country,
+        summary=candidate.summary,
+        key_skills=_normalize_skills(candidate.skills),
+        desired_pay_min=_currency_from_cents(candidate.desired_pay_min),
+        desired_pay_max=_currency_from_cents(candidate.desired_pay_max),
+        work_type=_format_work_type(candidate.work_type),
+        availability=candidate.availability,
+        updated_at=candidate.updated_at,
+    )
+
+
+def map_resume_to_opencats(resume: LocalResume, created_at: datetime | None = None) -> OpenCATSAttachment:
+    """Convert a stored resume to the OpenCATS attachment structure."""
+
+    return OpenCATSAttachment(
+        attachment_id=resume.id,
+        candidate_id=resume.candidate_id,
+        file_name=resume.file_name,
+        content_type=resume.content_type,
+        content_base64=resume.as_base64(),
+        created_at=created_at or datetime.utcnow(),
+    )
+
+
+def map_job_to_opencats(job: LocalJob) -> OpenCATSJobOrder:
+    """Convert an AutoHire job into the OpenCATS job order representation."""
+
+    return OpenCATSJobOrder(
+        job_id=job.id,
+        employer_id=job.employer_id,
+        title=job.title,
+        description=job.description,
+        city=job.city,
+        country=job.country,
+        salary_min=_currency_from_cents(job.salary_min),
+        salary_max=_currency_from_cents(job.salary_max),
+        work_type=_format_work_type(job.work_type),
+        external_id=job.external_id,
+        updated_at=job.updated_at,
+    )
+
+
+def map_application_to_opencats(bundle: LocalApplicationBundle) -> OpenCATSCandidateJobOrder:
+    """Create the OpenCATS join table payload for an application."""
+
+    application: LocalApplication = bundle.application
+    status = APPLICATION_STATUS_MAPPING.get(application.status, "Review")
+
+    resume_attachment_id: str | None = None
+    if bundle.resume is not None:
+        resume_attachment_id = bundle.resume.id
+
+    return OpenCATSCandidateJobOrder(
+        application_id=application.id,
+        candidate_id=application.candidate_id,
+        job_id=application.job_id,
+        status=status,
+        source=application.source,
+        resume_attachment_id=resume_attachment_id,
+        submitted_at=application.submitted_at,
+        updated_at=application.updated_at,
+    )
+

--- a/apps/api/app/opencats/models.py
+++ b/apps/api/app/opencats/models.py
@@ -1,0 +1,180 @@
+"""Pydantic models for OpenCATS synchronization."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel, EmailStr, Field, model_validator
+
+
+class WorkType(str, Enum):
+    """Supported work type categories."""
+
+    FULL_TIME = "full_time"
+    PART_TIME = "part_time"
+    CONTRACT = "contract"
+    TEMPORARY = "temporary"
+    INTERNSHIP = "internship"
+    OTHER = "other"
+
+
+class ApplicationStatus(str, Enum):
+    """Pipeline stages tracked for applications."""
+
+    NEW = "new"
+    SCREEN = "screen"
+    INTERVIEW = "interview"
+    OFFER = "offer"
+    HIRED = "hired"
+    REJECTED = "rejected"
+
+
+class LocalResume(BaseModel):
+    """Representation of a candidate resume stored within AutoHire."""
+
+    id: str
+    candidate_id: str
+    file_name: str
+    content_type: str
+    data: bytes
+
+    def as_base64(self) -> str:
+        """Return the resume payload encoded as base64 for transport."""
+
+        return base64.b64encode(self.data).decode("ascii")
+
+
+class LocalCandidate(BaseModel):
+    """Subset of the candidate profile required for OpenCATS."""
+
+    id: str
+    employer_id: str
+    email: EmailStr
+    first_name: str
+    last_name: str
+    phone: str | None = None
+    city: str | None = None
+    country: str | None = None
+    summary: str | None = None
+    desired_pay_min: int | None = Field(default=None, description="Stored in cents")
+    desired_pay_max: int | None = Field(default=None, description="Stored in cents")
+    work_type: WorkType | None = None
+    availability: str | None = None
+    skills: List[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class LocalJob(BaseModel):
+    """Job definition synchronized to OpenCATS."""
+
+    id: str
+    employer_id: str
+    title: str
+    description: str
+    city: str | None = None
+    country: str | None = None
+    salary_min: int | None = Field(default=None, description="Stored in cents")
+    salary_max: int | None = Field(default=None, description="Stored in cents")
+    work_type: WorkType | None = None
+    external_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class LocalApplication(BaseModel):
+    """Job application details required for synchronization."""
+
+    id: str
+    employer_id: str
+    candidate_id: str
+    job_id: str
+    status: ApplicationStatus
+    source: str | None = None
+    resume_id: str | None = None
+    submitted_at: datetime
+    updated_at: datetime
+
+
+class LocalApplicationBundle(BaseModel):
+    """Combination of application, candidate and job data for mapping."""
+
+    application: LocalApplication
+    candidate: LocalCandidate
+    job: LocalJob
+    resume: LocalResume | None = None
+
+    @model_validator(mode="after")
+    def validate_relationships(self) -> "LocalApplicationBundle":
+        """Ensure identifiers line up across nested models."""
+
+        if self.candidate.id != self.application.candidate_id:
+            raise ValueError("candidate.id must match application.candidate_id")
+        if self.job.id != self.application.job_id:
+            raise ValueError("job.id must match application.job_id")
+        if self.resume and self.resume.candidate_id != self.candidate.id:
+            raise ValueError("resume.candidate_id must match candidate.id")
+        return self
+
+
+class OpenCATSCandidate(BaseModel):
+    """Normalized OpenCATS candidate payload."""
+
+    candidate_id: str
+    first_name: str
+    last_name: str
+    email1: EmailStr
+    phone1: str | None = None
+    city: str | None = None
+    country: str | None = None
+    summary: str | None = None
+    key_skills: str | None = None
+    desired_pay_min: float | None = None
+    desired_pay_max: float | None = None
+    work_type: str | None = None
+    availability: str | None = None
+    updated_at: datetime
+
+
+class OpenCATSAttachment(BaseModel):
+    """Resume payload to be stored as an OpenCATS attachment."""
+
+    attachment_id: str
+    candidate_id: str
+    file_name: str
+    content_type: str
+    content_base64: str
+    created_at: datetime
+
+
+class OpenCATSJobOrder(BaseModel):
+    """Job order representation for OpenCATS."""
+
+    job_id: str
+    employer_id: str
+    title: str
+    description: str
+    city: str | None = None
+    country: str | None = None
+    salary_min: float | None = None
+    salary_max: float | None = None
+    work_type: str | None = None
+    external_id: str | None = None
+    updated_at: datetime
+
+
+class OpenCATSCandidateJobOrder(BaseModel):
+    """Join table mapping candidates to job orders with pipeline status."""
+
+    application_id: str
+    candidate_id: str
+    job_id: str
+    status: str
+    source: str | None = None
+    resume_attachment_id: str | None = None
+    submitted_at: datetime
+    updated_at: datetime
+

--- a/apps/api/app/routes/__init__.py
+++ b/apps/api/app/routes/__init__.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-from . import candidates, jobs
+from . import candidates, jobs, opencats
 
 api_router = APIRouter()
 api_router.include_router(candidates.router, prefix="/candidates", tags=["candidates"])
 api_router.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
+api_router.include_router(opencats.router, prefix="/opencats", tags=["opencats"])

--- a/apps/api/app/routes/opencats.py
+++ b/apps/api/app/routes/opencats.py
@@ -1,0 +1,87 @@
+"""API routes for OpenCATS synchronization."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.schemas.opencats import (
+    ApplicationSyncRequest,
+    CandidateSyncRequest,
+    ConfigListResponse,
+    JobSyncRequest,
+    LogListResponse,
+    ReconcileRequest,
+    SyncConfigResponse,
+    SyncConfigUpdate,
+    SyncLogResponse,
+    SyncResult,
+)
+from app.services.opencats_sync import (
+    SyncScope,
+    enqueue_sync_application,
+    enqueue_sync_candidate,
+    enqueue_sync_job,
+    get_recent_logs,
+    get_sync_config,
+    list_sync_configs,
+    set_sync_enabled,
+    trigger_reconcile,
+)
+
+
+router = APIRouter()
+
+
+@router.get("/configs", response_model=ConfigListResponse)
+def list_configs(scope: SyncScope | None = Query(default=None)) -> ConfigListResponse:
+    configs = list_sync_configs(scope=scope)
+    return ConfigListResponse(items=[SyncConfigResponse.from_config(cfg) for cfg in configs])
+
+
+@router.get("/configs/{scope}/{target_id}", response_model=SyncConfigResponse)
+def get_config(scope: SyncScope, target_id: str) -> SyncConfigResponse:
+    config = get_sync_config(scope, target_id)
+    if config is None:
+        raise HTTPException(status_code=404, detail="Sync configuration not found")
+    return SyncConfigResponse.from_config(config)
+
+
+@router.put("/configs/{scope}/{target_id}", response_model=SyncConfigResponse)
+def update_config(scope: SyncScope, target_id: str, payload: SyncConfigUpdate) -> SyncConfigResponse:
+    config = set_sync_enabled(scope, target_id, payload.enabled)
+    return SyncConfigResponse.from_config(config)
+
+
+@router.post("/sync/candidate", response_model=SyncResult)
+def sync_candidate(request: CandidateSyncRequest) -> SyncResult:
+    result = enqueue_sync_candidate(request.scope, request.target_id, request.candidate, request.resume)
+    return SyncResult(**result)
+
+
+@router.post("/sync/job", response_model=SyncResult)
+def sync_job(request: JobSyncRequest) -> SyncResult:
+    result = enqueue_sync_job(request.scope, request.target_id, request.job)
+    return SyncResult(**result)
+
+
+@router.post("/sync/application", response_model=SyncResult)
+def sync_application(request: ApplicationSyncRequest) -> SyncResult:
+    result = enqueue_sync_application(request.scope, request.target_id, request.bundle)
+    return SyncResult(**result)
+
+
+@router.post("/reconcile", response_model=SyncResult)
+def reconcile(request: ReconcileRequest) -> SyncResult:
+    result = trigger_reconcile(request.scope, request.target_id)
+    return SyncResult(**result)
+
+
+@router.get("/logs", response_model=LogListResponse)
+def list_logs(
+    scope: SyncScope | None = Query(default=None),
+    target_id: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+) -> LogListResponse:
+    logs = get_recent_logs(scope=scope, target_id=target_id, limit=limit)
+    return LogListResponse(items=[SyncLogResponse.from_log(entry) for entry in logs])
+

--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -1,0 +1,27 @@
+"""Pydantic schemas for the API."""
+
+from .opencats import (
+    ApplicationSyncRequest,
+    CandidateSyncRequest,
+    ConfigListResponse,
+    JobSyncRequest,
+    LogListResponse,
+    ReconcileRequest,
+    SyncConfigResponse,
+    SyncConfigUpdate,
+    SyncLogResponse,
+    SyncResult,
+)
+
+__all__ = [
+    "ApplicationSyncRequest",
+    "CandidateSyncRequest",
+    "ConfigListResponse",
+    "JobSyncRequest",
+    "LogListResponse",
+    "ReconcileRequest",
+    "SyncConfigResponse",
+    "SyncConfigUpdate",
+    "SyncLogResponse",
+    "SyncResult",
+]

--- a/apps/api/app/schemas/opencats.py
+++ b/apps/api/app/schemas/opencats.py
@@ -1,0 +1,108 @@
+"""API schemas for OpenCATS synchronization endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from app.opencats.models import LocalApplicationBundle, LocalCandidate, LocalJob, LocalResume
+from app.services.opencats_sync import (
+    SyncConfig,
+    SyncEntityType,
+    SyncLogEntry,
+    SyncScope,
+    SyncStatus,
+)
+
+
+class SyncConfigUpdate(BaseModel):
+    enabled: bool = Field(default=True, description="Enable or disable synchronization for the scope")
+
+
+class SyncConfigResponse(BaseModel):
+    scope: SyncScope
+    target_id: str
+    enabled: bool
+    last_synced_at: datetime | None = None
+    last_attempted_at: datetime | None = None
+    last_status: SyncStatus
+    retries: int
+    error: str | None = None
+
+    @classmethod
+    def from_config(cls, config: SyncConfig) -> "SyncConfigResponse":
+        return cls(
+            scope=config.scope,
+            target_id=config.target_id,
+            enabled=config.enabled,
+            last_synced_at=config.last_synced_at,
+            last_attempted_at=config.last_attempted_at,
+            last_status=config.last_status,
+            retries=config.retries,
+            error=config.error,
+        )
+
+
+class SyncLogResponse(BaseModel):
+    timestamp: datetime
+    scope: SyncScope
+    target_id: str
+    entity_type: SyncEntityType
+    status: SyncStatus
+    message: str
+    retry_count: int
+
+    @classmethod
+    def from_log(cls, log: SyncLogEntry) -> "SyncLogResponse":
+        return cls(
+            timestamp=log.timestamp,
+            scope=log.scope,
+            target_id=log.target_id,
+            entity_type=log.entity_type,
+            status=log.status,
+            message=log.message,
+            retry_count=log.retry_count,
+        )
+
+
+class CandidateSyncRequest(BaseModel):
+    scope: SyncScope
+    target_id: str
+    candidate: LocalCandidate
+    resume: LocalResume | None = None
+
+
+class JobSyncRequest(BaseModel):
+    scope: SyncScope
+    target_id: str
+    job: LocalJob
+
+
+class ApplicationSyncRequest(BaseModel):
+    scope: SyncScope
+    target_id: str
+    bundle: LocalApplicationBundle
+
+
+class ReconcileRequest(BaseModel):
+    scope: SyncScope
+    target_id: str
+
+
+class SyncResult(BaseModel):
+    status: str
+    message: str | None = None
+    payload: dict | None = None
+    error: str | None = None
+    retry: bool | None = None
+
+
+class ConfigListResponse(BaseModel):
+    items: List[SyncConfigResponse]
+
+
+class LogListResponse(BaseModel):
+    items: List[SyncLogResponse]
+

--- a/apps/api/app/services/__init__.py
+++ b/apps/api/app/services/__init__.py
@@ -1,0 +1,2 @@
+"""Service layer modules."""
+

--- a/apps/api/app/services/opencats_sync.py
+++ b/apps/api/app/services/opencats_sync.py
@@ -1,0 +1,298 @@
+"""State management for OpenCATS synchronization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Iterable, List, Tuple
+
+from app.opencats.models import LocalApplicationBundle, LocalCandidate, LocalJob, LocalResume
+
+
+class SyncScope(str, Enum):
+    ORGANIZATION = "organization"
+    JOB = "job"
+
+
+class SyncEntityType(str, Enum):
+    CANDIDATE = "candidate"
+    JOB = "job"
+    APPLICATION = "application"
+    RECONCILIATION = "reconciliation"
+
+
+class SyncStatus(str, Enum):
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    DISABLED = "disabled"
+
+
+@dataclass
+class SyncConfig:
+    scope: SyncScope
+    target_id: str
+    enabled: bool = False
+    last_synced_at: datetime | None = None
+    last_attempted_at: datetime | None = None
+    last_status: SyncStatus = SyncStatus.DISABLED
+    retries: int = 0
+    error: str | None = None
+
+
+@dataclass
+class SyncLogEntry:
+    timestamp: datetime
+    scope: SyncScope
+    target_id: str
+    entity_type: SyncEntityType
+    status: SyncStatus
+    message: str
+    retry_count: int = 0
+
+
+MAX_RETRIES = 3
+
+_SYNC_CONFIGS: Dict[Tuple[SyncScope, str], SyncConfig] = {}
+_SYNC_LOGS: List[SyncLogEntry] = []
+
+
+def _make_key(scope: SyncScope, target_id: str) -> Tuple[SyncScope, str]:
+    return scope, target_id
+
+
+def _log_entry(entry: SyncLogEntry) -> SyncLogEntry:
+    _SYNC_LOGS.append(entry)
+    return entry
+
+
+def ensure_sync_config(scope: SyncScope, target_id: str) -> SyncConfig:
+    key = _make_key(scope, target_id)
+    if key not in _SYNC_CONFIGS:
+        _SYNC_CONFIGS[key] = SyncConfig(scope=scope, target_id=target_id)
+    return _SYNC_CONFIGS[key]
+
+
+def set_sync_enabled(scope: SyncScope, target_id: str, enabled: bool) -> SyncConfig:
+    config = ensure_sync_config(scope, target_id)
+    config.enabled = enabled
+    config.last_status = SyncStatus.DISABLED if not enabled else config.last_status
+    if not enabled:
+        config.error = None
+        config.retries = 0
+    return config
+
+
+def get_sync_config(scope: SyncScope, target_id: str) -> SyncConfig | None:
+    return _SYNC_CONFIGS.get(_make_key(scope, target_id))
+
+
+def list_sync_configs(scope: SyncScope | None = None) -> List[SyncConfig]:
+    configs: Iterable[SyncConfig]
+    if scope is None:
+        configs = _SYNC_CONFIGS.values()
+    else:
+        configs = [cfg for cfg in _SYNC_CONFIGS.values() if cfg.scope == scope]
+    return sorted(configs, key=lambda cfg: (cfg.scope.value, cfg.target_id))
+
+
+def record_sync_attempt(scope: SyncScope, target_id: str, entity_type: SyncEntityType) -> SyncLogEntry:
+    config = ensure_sync_config(scope, target_id)
+    config.last_attempted_at = datetime.utcnow()
+    config.last_status = SyncStatus.PENDING
+    return _log_entry(
+        SyncLogEntry(
+            timestamp=config.last_attempted_at,
+            scope=scope,
+            target_id=target_id,
+            entity_type=entity_type,
+            status=SyncStatus.PENDING,
+            message="Synchronization started",
+            retry_count=config.retries,
+        )
+    )
+
+
+def record_sync_success(scope: SyncScope, target_id: str, entity_type: SyncEntityType, message: str) -> SyncLogEntry:
+    config = ensure_sync_config(scope, target_id)
+    config.last_synced_at = datetime.utcnow()
+    config.last_status = SyncStatus.SUCCESS
+    config.error = None
+    config.retries = 0
+    return _log_entry(
+        SyncLogEntry(
+            timestamp=config.last_synced_at,
+            scope=scope,
+            target_id=target_id,
+            entity_type=entity_type,
+            status=SyncStatus.SUCCESS,
+            message=message,
+            retry_count=config.retries,
+        )
+    )
+
+
+def record_sync_failure(scope: SyncScope, target_id: str, entity_type: SyncEntityType, message: str) -> tuple[SyncLogEntry, bool]:
+    config = ensure_sync_config(scope, target_id)
+    config.retries += 1
+    config.last_status = SyncStatus.FAILED
+    config.error = message
+    timestamp = datetime.utcnow()
+    entry = _log_entry(
+        SyncLogEntry(
+            timestamp=timestamp,
+            scope=scope,
+            target_id=target_id,
+            entity_type=entity_type,
+            status=SyncStatus.FAILED,
+            message=message,
+            retry_count=config.retries,
+        )
+    )
+    should_retry = config.retries < MAX_RETRIES
+    return entry, should_retry
+
+
+def record_sync_skip(scope: SyncScope, target_id: str, entity_type: SyncEntityType, reason: str) -> SyncLogEntry:
+    config = ensure_sync_config(scope, target_id)
+    config.last_status = SyncStatus.SKIPPED
+    config.error = None
+    return _log_entry(
+        SyncLogEntry(
+            timestamp=datetime.utcnow(),
+            scope=scope,
+            target_id=target_id,
+            entity_type=entity_type,
+            status=SyncStatus.SKIPPED,
+            message=reason,
+            retry_count=config.retries,
+        )
+    )
+
+
+def get_recent_logs(scope: SyncScope | None = None, target_id: str | None = None, limit: int = 20) -> List[SyncLogEntry]:
+    filtered = [
+        entry
+        for entry in _SYNC_LOGS
+        if (scope is None or entry.scope == scope) and (target_id is None or entry.target_id == target_id)
+    ]
+    filtered.sort(key=lambda entry: entry.timestamp, reverse=True)
+    return filtered[:limit]
+
+
+def reset_sync_state() -> None:
+    _SYNC_CONFIGS.clear()
+    _SYNC_LOGS.clear()
+
+
+def serialize_sync_config(config: SyncConfig) -> dict[str, object]:
+    return {
+        "scope": config.scope.value,
+        "target_id": config.target_id,
+        "enabled": config.enabled,
+        "last_synced_at": config.last_synced_at.isoformat() if config.last_synced_at else None,
+        "last_attempted_at": config.last_attempted_at.isoformat() if config.last_attempted_at else None,
+        "last_status": config.last_status.value,
+        "retries": config.retries,
+        "error": config.error,
+    }
+
+
+def serialize_log_entry(entry: SyncLogEntry) -> dict[str, object]:
+    return {
+        "timestamp": entry.timestamp.isoformat(),
+        "scope": entry.scope.value,
+        "target_id": entry.target_id,
+        "entity_type": entry.entity_type.value,
+        "status": entry.status.value,
+        "message": entry.message,
+        "retry_count": entry.retry_count,
+    }
+
+
+def enqueue_sync_candidate(scope: SyncScope, target_id: str, candidate: LocalCandidate, resume: LocalResume | None = None) -> dict[str, object]:
+    from app.tasks.opencats import sync_entity_task
+
+    if not ensure_sync_config(scope, target_id).enabled:
+        entry = record_sync_skip(scope, target_id, SyncEntityType.CANDIDATE, "Sync disabled for scope")
+        return {"status": entry.status.value, "message": entry.message}
+
+    payload = {
+        "entity": candidate.model_dump(mode="json"),
+        "resume": _serialize_resume(resume),
+    }
+    return _execute_with_retries(
+        sync_entity_task,
+        scope,
+        target_id,
+        SyncEntityType.CANDIDATE,
+        payload,
+    )
+
+
+def enqueue_sync_job(scope: SyncScope, target_id: str, job: LocalJob) -> dict[str, object]:
+    from app.tasks.opencats import sync_entity_task
+
+    if not ensure_sync_config(scope, target_id).enabled:
+        entry = record_sync_skip(scope, target_id, SyncEntityType.JOB, "Sync disabled for scope")
+        return {"status": entry.status.value, "message": entry.message}
+
+    payload = {"entity": job.model_dump(mode="json")}
+    return _execute_with_retries(
+        sync_entity_task,
+        scope,
+        target_id,
+        SyncEntityType.JOB,
+        payload,
+    )
+
+
+def enqueue_sync_application(scope: SyncScope, target_id: str, bundle: LocalApplicationBundle) -> dict[str, object]:
+    from app.tasks.opencats import sync_entity_task
+
+    if not ensure_sync_config(scope, target_id).enabled:
+        entry = record_sync_skip(scope, target_id, SyncEntityType.APPLICATION, "Sync disabled for scope")
+        return {"status": entry.status.value, "message": entry.message}
+
+    bundle_payload = bundle.model_dump(mode="json")
+    if bundle.resume is not None and bundle_payload.get("resume") is not None:
+        bundle_payload["resume"]["data"] = bundle.resume.as_base64()
+    payload = {"entity": bundle_payload}
+    return _execute_with_retries(
+        sync_entity_task,
+        scope,
+        target_id,
+        SyncEntityType.APPLICATION,
+        payload,
+    )
+
+
+def trigger_reconcile(scope: SyncScope, target_id: str) -> dict[str, object]:
+    from app.tasks.opencats import reconcile_task
+
+    payload = {"scope": scope.value, "target_id": target_id}
+    result = reconcile_task.apply_async(args=[scope.value, target_id]).get()
+    return result | {"payload": payload}
+
+
+def _execute_with_retries(task, scope: SyncScope, target_id: str, entity_type: SyncEntityType, payload: dict[str, object]) -> dict[str, object]:
+    attempt = 0
+    result: dict[str, object] | None = None
+    while attempt <= MAX_RETRIES:
+        async_result = task.apply_async(args=[scope.value, target_id, entity_type.value, payload])
+        result = async_result.get()
+        if result.get("status") != SyncStatus.FAILED.value or not result.get("retry"):
+            break
+        attempt += 1
+    return result or {"status": SyncStatus.FAILED.value, "message": "Task execution failed"}
+
+
+def _serialize_resume(resume: LocalResume | None) -> dict[str, object] | None:
+    if resume is None:
+        return None
+    payload = resume.model_dump(mode="json")
+    payload["data"] = resume.as_base64()
+    return payload
+

--- a/apps/api/app/tasks/__init__.py
+++ b/apps/api/app/tasks/__init__.py
@@ -1,0 +1,6 @@
+"""Task modules for AutoHire."""
+
+from .celery_app import celery_app
+
+__all__ = ["celery_app"]
+

--- a/apps/api/app/tasks/celery_app.py
+++ b/apps/api/app/tasks/celery_app.py
@@ -1,0 +1,24 @@
+"""Celery application configuration for AutoHire."""
+
+from __future__ import annotations
+
+from celery import Celery
+
+from app.core.config import get_settings
+
+
+settings = get_settings()
+
+if settings.celery_task_eager:
+    broker_url = "memory://"
+    backend_url = "cache+memory://"
+else:
+    broker_url = settings.redis_url
+    backend_url = settings.redis_url
+
+celery_app = Celery("autohire", broker=broker_url, backend=backend_url)
+
+celery_app.conf.update(task_always_eager=settings.celery_task_eager)
+
+__all__ = ["celery_app"]
+

--- a/apps/api/app/tasks/opencats.py
+++ b/apps/api/app/tasks/opencats.py
@@ -1,0 +1,109 @@
+"""Celery tasks orchestrating synchronization with OpenCATS."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict
+
+from pydantic import ValidationError
+
+from app.opencats import OpenCATSClient
+from app.opencats.models import LocalApplicationBundle, LocalCandidate, LocalJob, LocalResume
+from app.services.opencats_sync import (
+    SyncEntityType,
+    SyncScope,
+    SyncStatus,
+    record_sync_attempt,
+    record_sync_failure,
+    record_sync_success,
+)
+
+from .celery_app import celery_app
+
+
+def _decode_resume_payload(payload: Dict[str, Any] | None) -> Dict[str, Any] | None:
+    if payload is None:
+        return None
+    if "data" in payload and isinstance(payload["data"], str):
+        payload = payload.copy()
+        payload["data"] = base64.b64decode(payload["data"])
+    return payload
+
+
+@celery_app.task(name="opencats.sync_entity")
+def sync_entity_task(scope: str, target_id: str, entity_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    scope_enum = SyncScope(scope)
+    entity_enum = SyncEntityType(entity_type)
+    record_sync_attempt(scope_enum, target_id, entity_enum)
+    client = OpenCATSClient()
+
+    try:
+        if entity_enum is SyncEntityType.CANDIDATE:
+            candidate = LocalCandidate.model_validate(payload["entity"])
+            resume_data = _decode_resume_payload(payload.get("resume"))
+            resume = LocalResume.model_validate(resume_data) if resume_data else None
+            body = client.build_candidate_payload(candidate, resume)
+            record_sync_success(
+                scope_enum,
+                target_id,
+                entity_enum,
+                f"Candidate {candidate.id} prepared for sync",
+            )
+            return {"status": SyncStatus.SUCCESS.value, "payload": body}
+
+        if entity_enum is SyncEntityType.JOB:
+            job = LocalJob.model_validate(payload["entity"])
+            body = client.build_job_payload(job)
+            record_sync_success(
+                scope_enum,
+                target_id,
+                entity_enum,
+                f"Job {job.id} prepared for sync",
+            )
+            return {"status": SyncStatus.SUCCESS.value, "payload": body}
+
+        if entity_enum is SyncEntityType.APPLICATION:
+            bundle_payload = payload["entity"].copy()
+            resume_payload = _decode_resume_payload(bundle_payload.get("resume"))
+            if resume_payload is not None:
+                bundle_payload["resume"] = resume_payload
+            bundle = LocalApplicationBundle.model_validate(bundle_payload)
+            body = client.build_application_payload(bundle)
+            record_sync_success(
+                scope_enum,
+                target_id,
+                entity_enum,
+                f"Application {bundle.application.id} prepared for sync",
+            )
+            return {"status": SyncStatus.SUCCESS.value, "payload": body}
+
+        raise ValueError(f"Unsupported entity type '{entity_type}'")
+
+    except (ValidationError, KeyError, ValueError) as exc:
+        _, should_retry = record_sync_failure(
+            scope_enum,
+            target_id,
+            entity_enum,
+            f"Validation failed: {exc}",
+        )
+        return {"status": SyncStatus.FAILED.value, "error": str(exc), "retry": should_retry}
+    except Exception as exc:  # pragma: no cover - defensive guard
+        _, should_retry = record_sync_failure(
+            scope_enum,
+            target_id,
+            entity_enum,
+            f"Unexpected error: {exc}",
+        )
+        return {"status": SyncStatus.FAILED.value, "error": str(exc), "retry": should_retry}
+
+
+@celery_app.task(name="opencats.reconcile")
+def reconcile_task(scope: str, target_id: str) -> Dict[str, Any]:
+    scope_enum = SyncScope(scope)
+    entity_enum = SyncEntityType.RECONCILIATION
+    record_sync_attempt(scope_enum, target_id, entity_enum)
+    client = OpenCATSClient()
+    payload = client.build_reconcile_payload(scope, target_id)
+    record_sync_success(scope_enum, target_id, entity_enum, "Reconciliation request prepared")
+    return {"status": SyncStatus.SUCCESS.value, "payload": payload}
+

--- a/apps/api/tests/__init__.py
+++ b/apps/api/tests/__init__.py
@@ -1,0 +1,13 @@
+"""Tests package for AutoHire API."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Test configuration for the AutoHire API package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.services.opencats_sync import reset_sync_state
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+@pytest.fixture(autouse=True)
+def cleanup_sync_state() -> None:
+    """Reset in-memory sync state around each test."""
+
+    reset_sync_state()
+    yield
+    reset_sync_state()
+

--- a/apps/api/tests/test_opencats_mappers.py
+++ b/apps/api/tests/test_opencats_mappers.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime
+from app.opencats.mappers import (
+    map_application_to_opencats,
+    map_candidate_to_opencats,
+    map_job_to_opencats,
+    map_resume_to_opencats,
+)
+from app.opencats.models import (
+    ApplicationStatus,
+    LocalApplication,
+    LocalApplicationBundle,
+    LocalCandidate,
+    LocalJob,
+    LocalResume,
+    WorkType,
+)
+
+
+def _now() -> datetime:
+    return datetime(2024, 1, 1, 12, 0, 0)
+
+
+def test_map_candidate_to_opencats_rounds_currency_and_skills() -> None:
+    candidate = LocalCandidate(
+        id="cand-1",
+        employer_id="org-1",
+        email="person@example.com",
+        first_name="Jane",
+        last_name="Doe",
+        phone="+15551234567",
+        city="Berlin",
+        country="DE",
+        summary="Seasoned data engineer",
+        desired_pay_min=8800000,
+        desired_pay_max=10500000,
+        work_type=WorkType.FULL_TIME,
+        availability="Immediate",
+        skills=["Python", "sql", "Python"],
+        created_at=_now(),
+        updated_at=_now(),
+    )
+
+    result = map_candidate_to_opencats(candidate)
+
+    assert result.desired_pay_min == 88000.0
+    assert result.desired_pay_max == 105000.0
+    assert result.key_skills == "Python, Sql"
+    assert result.work_type == "Full Time"
+
+
+def test_map_resume_to_opencats_base64_encodes_content() -> None:
+    resume = LocalResume(
+        id="resume-1",
+        candidate_id="cand-1",
+        file_name="cv.pdf",
+        content_type="application/pdf",
+        data=b"pdf-bytes",
+    )
+
+    mapped = map_resume_to_opencats(resume, created_at=_now())
+    assert mapped.content_base64 == resume.as_base64()
+    assert mapped.candidate_id == resume.candidate_id
+
+
+def test_map_job_to_opencats_preserves_external_identifier() -> None:
+    job = LocalJob(
+        id="job-1",
+        employer_id="org-1",
+        title="Senior Engineer",
+        description="Design systems",
+        city="Munich",
+        country="DE",
+        salary_min=9000000,
+        salary_max=12000000,
+        work_type=WorkType.CONTRACT,
+        external_id="ATS-123",
+        created_at=_now(),
+        updated_at=_now(),
+    )
+
+    mapped = map_job_to_opencats(job)
+    assert mapped.external_id == "ATS-123"
+    assert mapped.salary_min == 90000.0
+    assert mapped.work_type == "Contract"
+
+
+def test_map_application_to_opencats_sets_status_and_resume_link() -> None:
+    candidate = LocalCandidate(
+        id="cand-1",
+        employer_id="org-1",
+        email="person@example.com",
+        first_name="Jane",
+        last_name="Doe",
+        phone=None,
+        city="Berlin",
+        country="DE",
+        summary=None,
+        desired_pay_min=None,
+        desired_pay_max=None,
+        work_type=None,
+        availability=None,
+        skills=[],
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    job = LocalJob(
+        id="job-1",
+        employer_id="org-1",
+        title="Engineer",
+        description="Build things",
+        city="Berlin",
+        country="DE",
+        salary_min=None,
+        salary_max=None,
+        work_type=None,
+        external_id=None,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    application = LocalApplication(
+        id="app-1",
+        employer_id="org-1",
+        candidate_id=candidate.id,
+        job_id=job.id,
+        status=ApplicationStatus.INTERVIEW,
+        source="Referral",
+        resume_id="resume-1",
+        submitted_at=_now(),
+        updated_at=_now(),
+    )
+    resume = LocalResume(
+        id="resume-1",
+        candidate_id=candidate.id,
+        file_name="cv.pdf",
+        content_type="application/pdf",
+        data=b"binary",
+    )
+
+    bundle = LocalApplicationBundle(application=application, candidate=candidate, job=job, resume=resume)
+
+    mapped = map_application_to_opencats(bundle)
+    assert mapped.status == "Interview"
+    assert mapped.resume_attachment_id == "resume-1"
+    assert mapped.application_id == application.id
+

--- a/apps/api/tests/test_opencats_sync.py
+++ b/apps/api/tests/test_opencats_sync.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.opencats_sync import MAX_RETRIES, SyncScope, get_sync_config
+
+
+client = TestClient(app)
+
+
+def _timestamp() -> str:
+    return datetime(2024, 1, 1, 12, 0, 0).isoformat()
+
+
+def _resume_payload(candidate_id: str) -> dict[str, str]:
+    return {
+        "id": "resume-1",
+        "candidate_id": candidate_id,
+        "file_name": "resume.pdf",
+        "content_type": "application/pdf",
+        "data": base64.b64encode(b"resume-bytes").decode("ascii"),
+    }
+
+
+def _candidate_payload(candidate_id: str, employer_id: str) -> dict[str, object]:
+    return {
+        "id": candidate_id,
+        "employer_id": employer_id,
+        "email": "candidate@example.com",
+        "first_name": "Ava",
+        "last_name": "Smith",
+        "phone": "+15551230000",
+        "city": "Berlin",
+        "country": "DE",
+        "summary": "Platform engineer",
+        "desired_pay_min": 7200000,
+        "desired_pay_max": 8600000,
+        "work_type": "full_time",
+        "availability": "2 weeks",
+        "skills": ["python", "fastapi"],
+        "created_at": _timestamp(),
+        "updated_at": _timestamp(),
+    }
+
+
+def test_sync_candidate_success_and_log_entries() -> None:
+    scope = SyncScope.ORGANIZATION.value
+    target_id = "org-sync"
+
+    response = client.put(f"/api/opencats/configs/{scope}/{target_id}", json={"enabled": True})
+    assert response.status_code == 200
+
+    payload = {
+        "scope": scope,
+        "target_id": target_id,
+        "candidate": _candidate_payload("cand-100", target_id),
+        "resume": _resume_payload("cand-100"),
+    }
+
+    result = client.post("/api/opencats/sync/candidate", json=payload)
+    assert result.status_code == 200
+    data = result.json()
+    assert data["status"] == "success"
+    assert data["payload"]["candidate"]["candidate_id"] == "cand-100"
+
+    logs = client.get(
+        "/api/opencats/logs",
+        params={"scope": scope, "target_id": target_id, "limit": 5},
+    ).json()
+    assert len(logs["items"]) >= 2
+    assert logs["items"][0]["status"] in {"success", "pending"}
+
+    reconcile = client.post("/api/opencats/reconcile", json={"scope": scope, "target_id": target_id})
+    assert reconcile.status_code == 200
+    reconcile_payload = reconcile.json()
+    assert reconcile_payload["status"] == "success"
+    assert reconcile_payload["payload"]["scope"] == scope
+
+
+def test_sync_candidate_failure_uses_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    scope = SyncScope.ORGANIZATION.value
+    target_id = "org-error"
+
+    client.put(f"/api/opencats/configs/{scope}/{target_id}", json={"enabled": True})
+
+    def _raise_error(*args, **kwargs):  # pragma: no cover - invoked via monkeypatch
+        raise ValueError("boom")
+
+    monkeypatch.setattr("app.tasks.opencats.OpenCATSClient.build_candidate_payload", _raise_error)
+
+    payload = {
+        "scope": scope,
+        "target_id": target_id,
+        "candidate": _candidate_payload("cand-200", target_id),
+        "resume": _resume_payload("cand-200"),
+    }
+
+    response = client.post("/api/opencats/sync/candidate", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["retry"] is False
+
+    config = get_sync_config(SyncScope.ORGANIZATION, target_id)
+    assert config is not None
+    assert config.retries == MAX_RETRIES
+    assert config.last_status.value == "failed"
+

--- a/apps/employer-portal/app/page.tsx
+++ b/apps/employer-portal/app/page.tsx
@@ -1,20 +1,298 @@
-export default function HomePage() {
+'use client';
+
+import { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+type SyncScope = 'organization' | 'job';
+
+type SyncConfig = {
+  scope: SyncScope;
+  target_id: string;
+  enabled: boolean;
+  last_status: string;
+  last_synced_at: string | null;
+  retries: number;
+  error: string | null;
+};
+
+type SyncLog = {
+  timestamp: string;
+  scope: SyncScope;
+  target_id: string;
+  entity_type: string;
+  status: string;
+  message: string;
+  retry_count: number;
+};
+
+type JobRow = {
+  id: string;
+  title: string;
+  enabled: boolean;
+  status: string;
+  lastSyncedAt: string | null;
+};
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:8000';
+const DEFAULT_ORG_ID = 'org-sync';
+const DEFAULT_JOBS: JobRow[] = [
+  { id: 'job-1001', title: 'Backend Engineer', enabled: false, status: 'disabled', lastSyncedAt: null },
+  { id: 'job-1002', title: 'Data Scientist', enabled: false, status: 'disabled', lastSyncedAt: null },
+  { id: 'job-1003', title: 'Product Designer', enabled: false, status: 'disabled', lastSyncedAt: null },
+];
+
+async function updateConfig(scope: SyncScope, targetId: string, enabled: boolean): Promise<SyncConfig | null> {
+  try {
+    const response = await fetch(`${API_BASE}/api/opencats/configs/${scope}/${targetId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to update ${scope} configuration`);
+    }
+    return (await response.json()) as SyncConfig;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+async function fetchConfigs(scope?: SyncScope): Promise<SyncConfig[]> {
+  const params = scope ? `?scope=${scope}` : '';
+  try {
+    const response = await fetch(`${API_BASE}/api/opencats/configs${params}`);
+    if (!response.ok) {
+      throw new Error('Unable to fetch sync configurations');
+    }
+    const payload = (await response.json()) as { items: SyncConfig[] };
+    return payload.items;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+async function fetchLogs(limit = 15): Promise<SyncLog[]> {
+  try {
+    const response = await fetch(`${API_BASE}/api/opencats/logs?limit=${limit}`);
+    if (!response.ok) {
+      throw new Error('Unable to load sync logs');
+    }
+    const payload = (await response.json()) as { items: SyncLog[] };
+    return payload.items;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  return date.toLocaleString();
+}
+
+export default function EmployerSyncPage(): JSX.Element {
+  const [organizationEnabled, setOrganizationEnabled] = useState(false);
+  const [jobs, setJobs] = useState<JobRow[]>(DEFAULT_JOBS);
+  const [logs, setLogs] = useState<SyncLog[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const [lastFetched, setLastFetched] = useState<string | null>(null);
+
+  const organizationStatus = useMemo(() => {
+    const orgLogs = logs.filter((log) => log.scope === 'organization' && log.target_id === DEFAULT_ORG_ID);
+    return orgLogs.length > 0 ? orgLogs[0].status : organizationEnabled ? 'enabled' : 'disabled';
+  }, [logs, organizationEnabled]);
+
+  const refreshAll = useCallback(async () => {
+    setIsBusy(true);
+    const [configs, remoteLogs] = await Promise.all([fetchConfigs(), fetchLogs()]);
+    setLogs(remoteLogs);
+
+    const organizationConfig = configs.find((config) => config.scope === 'organization' && config.target_id === DEFAULT_ORG_ID);
+    setOrganizationEnabled(Boolean(organizationConfig?.enabled));
+
+    setJobs((current) =>
+      current.map((job) => {
+        const jobConfig = configs.find((config) => config.scope === 'job' && config.target_id === job.id);
+        return {
+          ...job,
+          enabled: jobConfig?.enabled ?? job.enabled,
+          status: jobConfig?.last_status ?? job.status,
+          lastSyncedAt: jobConfig?.last_synced_at ?? job.lastSyncedAt,
+        };
+      }),
+    );
+
+    setLastFetched(new Date().toISOString());
+    setIsBusy(false);
+  }, []);
+
+  useEffect(() => {
+    void refreshAll();
+  }, [refreshAll]);
+
+  const handleOrganizationToggle = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const enabled = event.target.checked;
+      setOrganizationEnabled(enabled);
+      setError(null);
+      const updated = await updateConfig('organization', DEFAULT_ORG_ID, enabled);
+      if (!updated) {
+        setError('Unable to update organization sync settings.');
+        setOrganizationEnabled((prev) => !prev);
+        return;
+      }
+      setOrganizationEnabled(updated.enabled);
+      void refreshAll();
+    },
+    [refreshAll],
+  );
+
+  const handleJobToggle = useCallback(
+    async (jobId: string, enabled: boolean) => {
+      setJobs((current) => current.map((job) => (job.id === jobId ? { ...job, enabled } : job)));
+      setError(null);
+      const updated = await updateConfig('job', jobId, enabled);
+      if (!updated) {
+        setError('Unable to update job sync settings.');
+        setJobs((current) => current.map((job) => (job.id === jobId ? { ...job, enabled: !enabled } : job)));
+        return;
+      }
+      setJobs((current) =>
+        current.map((job) =>
+          job.id === jobId
+            ? {
+                ...job,
+                enabled: updated.enabled,
+                status: updated.last_status,
+                lastSyncedAt: updated.last_synced_at,
+              }
+            : job,
+        ),
+      );
+      void refreshAll();
+    },
+    [refreshAll],
+  );
+
   return (
-    <main style={{ padding: "4rem", maxWidth: "960px", margin: "0 auto" }}>
-      <h1>AutoHire Employer Portal</h1>
-      <p>
-        This placeholder interface represents the future recruiter and hiring manager
-        experience. The production version will provide job authoring, applicant pipelines,
-        microtask campaigns, sourcing tools, scheduling, and OpenCATS synchronization.
-      </p>
-      <ul>
-        <li>Organization and team management</li>
-        <li>Job pipelines with screening workflows</li>
-        <li>Microtask campaign setup and review</li>
-      </ul>
-      <p>
-        Consult the documentation to understand how these capabilities will be implemented.
-      </p>
+    <main style={{ padding: '3rem', maxWidth: '1100px', margin: '0 auto' }}>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1 style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>ATS Synchronization</h1>
+        <p style={{ color: '#475569', maxWidth: '800px' }}>
+          Control how AutoHire shares jobs, candidates, and applications with your OpenCATS instance. Use the toggles below to
+          enable synchronization at the organization or per-job level and review recent activity logs.
+        </p>
+        {error ? <p style={{ color: '#b91c1c' }}>{error}</p> : null}
+        <button
+          type="button"
+          onClick={() => {
+            setError(null);
+            void refreshAll();
+          }}
+          style={{ marginTop: '1rem', padding: '0.5rem 1.25rem', borderRadius: '0.5rem', backgroundColor: '#2563eb', color: 'white' }}
+        >
+          Refresh data
+        </button>
+        <p style={{ fontSize: '0.875rem', color: '#64748b', marginTop: '0.75rem' }}>
+          Last refreshed: {lastFetched ? formatTimestamp(lastFetched) : 'Loading…'} {isBusy ? '(updating…) ' : ''}
+        </p>
+      </header>
+
+      <section style={{ marginBottom: '2.5rem', padding: '1.5rem', border: '1px solid #e2e8f0', borderRadius: '0.75rem' }}>
+        <h2 style={{ fontSize: '1.25rem', marginBottom: '0.75rem' }}>Organization-wide sync</h2>
+        <p style={{ color: '#475569', marginBottom: '1rem' }}>
+          When enabled, candidate and application updates from every job will be sent to OpenCATS. Disable to pause all outbound
+          updates while keeping existing mappings intact.
+        </p>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', fontWeight: 500 }}>
+          <input type="checkbox" checked={organizationEnabled} onChange={handleOrganizationToggle} />
+          Sync for organization <code>{DEFAULT_ORG_ID}</code>
+          <span style={{ fontSize: '0.875rem', color: '#64748b' }}>Status: {organizationStatus}</span>
+        </label>
+      </section>
+
+      <section style={{ marginBottom: '2.5rem', padding: '1.5rem', border: '1px solid #e2e8f0', borderRadius: '0.75rem' }}>
+        <h2 style={{ fontSize: '1.25rem', marginBottom: '0.75rem' }}>Job-level overrides</h2>
+        <p style={{ color: '#475569', marginBottom: '1rem' }}>
+          Toggle sync per job to keep drafts private or to correct mappings before sending updates.
+        </p>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ textAlign: 'left', borderBottom: '1px solid #e2e8f0' }}>
+              <th style={{ padding: '0.75rem' }}>Job</th>
+              <th style={{ padding: '0.75rem' }}>Status</th>
+              <th style={{ padding: '0.75rem' }}>Last synced</th>
+              <th style={{ padding: '0.75rem', textAlign: 'right' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map((job) => (
+              <tr key={job.id} style={{ borderBottom: '1px solid #e2e8f0' }}>
+                <td style={{ padding: '0.75rem' }}>
+                  <div style={{ fontWeight: 600 }}>{job.title}</div>
+                  <div style={{ fontSize: '0.875rem', color: '#64748b' }}>Job ID: {job.id}</div>
+                </td>
+                <td style={{ padding: '0.75rem' }}>{job.status}</td>
+                <td style={{ padding: '0.75rem' }}>{formatTimestamp(job.lastSyncedAt)}</td>
+                <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                  <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <input
+                      type="checkbox"
+                      checked={job.enabled}
+                      onChange={(event) => void handleJobToggle(job.id, event.target.checked)}
+                    />
+                    Enable sync
+                  </label>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section style={{ padding: '1.5rem', border: '1px solid #e2e8f0', borderRadius: '0.75rem' }}>
+        <h2 style={{ fontSize: '1.25rem', marginBottom: '0.75rem' }}>Recent sync activity</h2>
+        <p style={{ color: '#475569', marginBottom: '1rem' }}>
+          These entries summarize the most recent synchronization attempts sent to OpenCATS. Review errors to understand why a
+          record may require manual intervention or a retry from the API.
+        </p>
+        {logs.length === 0 ? (
+          <p style={{ color: '#94a3b8' }}>No logs available yet.</p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '1px solid #e2e8f0' }}>
+                <th style={{ padding: '0.75rem' }}>Timestamp</th>
+                <th style={{ padding: '0.75rem' }}>Scope</th>
+                <th style={{ padding: '0.75rem' }}>Target</th>
+                <th style={{ padding: '0.75rem' }}>Entity</th>
+                <th style={{ padding: '0.75rem' }}>Status</th>
+                <th style={{ padding: '0.75rem' }}>Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={`${log.timestamp}-${log.target_id}-${log.entity_type}`} style={{ borderBottom: '1px solid #e2e8f0' }}>
+                  <td style={{ padding: '0.75rem' }}>{formatTimestamp(log.timestamp)}</td>
+                  <td style={{ padding: '0.75rem' }}>{log.scope}</td>
+                  <td style={{ padding: '0.75rem' }}>{log.target_id}</td>
+                  <td style={{ padding: '0.75rem' }}>{log.entity_type}</td>
+                  <td style={{ padding: '0.75rem' }}>{log.status}</td>
+                  <td style={{ padding: '0.75rem' }}>
+                    {log.message}
+                    {log.retry_count > 0 ? (
+                      <span style={{ marginLeft: '0.5rem', color: '#b45309' }}>(retry #{log.retry_count})</span>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add OpenCATS mapping models, Celery tasks, and sync management endpoints in the API
- capture sync configuration, logging, and retries with supporting unit tests
- expose employer portal UI to toggle OpenCATS sync and review recent activity logs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d348d072bc832d904ac71b34d11ebf