### PR TITLE
Add GitHub Actions pipelines for CI, Docker builds, and deploy automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,184 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/**'
+      - 'infrastructure/**'
+      - '.github/workflows/ci.yml'
+      - 'mypy.ini'
+  pull_request:
+    paths:
+      - 'apps/**'
+      - 'infrastructure/**'
+      - '.github/workflows/**'
+      - 'mypy.ini'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (${{ matrix.app }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - candidate-portal
+          - employer-portal
+          - admin-console
+    env:
+      NEXT_TELEMETRY_DISABLED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ matrix.app }}-${{ hashFiles(format('apps/{0}/package-lock.json', matrix.app), format('apps/{0}/package.json', matrix.app)) }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ matrix.app }}-
+            ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        working-directory: apps/${{ matrix.app }}
+        run: npm install --no-audit --no-fund
+
+      - name: Lint
+        working-directory: apps/${{ matrix.app }}
+        run: |
+          set -o pipefail
+          mkdir -p reports
+          npm run lint -- --max-warnings=0 --format junit --output-file reports/eslint.xml | tee reports/eslint.log
+
+      - name: Type check
+        working-directory: apps/${{ matrix.app }}
+        run: |
+          set -o pipefail
+          npx tsc --noEmit --pretty false | tee reports/tsc.log
+
+      - name: Build
+        working-directory: apps/${{ matrix.app }}
+        run: |
+          set -o pipefail
+          npm run build | tee reports/build.log
+
+      - name: Test
+        working-directory: apps/${{ matrix.app }}
+        run: |
+          set -o pipefail
+          mkdir -p reports
+          if npm run test --if-present -- --watch=false 2>&1 | tee reports/tests.log; then
+            if [ ! -s reports/tests.log ]; then
+              echo "No tests defined for ${{ matrix.app }}." | tee -a reports/tests.log
+            fi
+          else
+            exit 1
+          fi
+
+      - name: Upload frontend artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.app }}-frontend-reports
+          path: |
+            apps/${{ matrix.app }}/reports/**
+          if-no-files-found: warn
+
+  backend:
+    name: Backend (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - api
+          - worker
+    env:
+      PYTHONUNBUFFERED: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            apps/${{ matrix.service }}/requirements.txt
+            mypy.ini
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -eo pipefail
+          python -m pip install --upgrade pip
+          if [ "${{ matrix.service }}" = "api" ]; then
+            pip install -r apps/api/requirements.txt
+          else
+            pip install -r <(grep -v '^meilisearch' apps/worker/requirements.txt)
+            pip install 'meilisearch>=0.30,<0.31'
+          fi
+          pip install pytest mypy ruff
+
+      - name: Lint
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p apps/${{ matrix.service }}/reports
+          ruff check apps/${{ matrix.service }} | tee apps/${{ matrix.service }}/reports/ruff.txt
+
+      - name: Type check
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p apps/${{ matrix.service }}/reports
+          mypy --config-file mypy.ini apps/${{ matrix.service }} | tee apps/${{ matrix.service }}/reports/mypy.txt
+
+      - name: Test
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p apps/${{ matrix.service }}/reports
+          if [ "${{ matrix.service }}" = "api" ]; then
+            export DATABASE_URL="sqlite+aiosqlite:///:memory:"
+            export REDIS_URL="redis://localhost:6379/0"
+            export MINIO_ENDPOINT="http://localhost:9000"
+            export MINIO_ACCESS_KEY="ci"
+            export MINIO_SECRET_KEY="ci"
+            export MEILISEARCH_URL="http://localhost:7700"
+            export MEILISEARCH_API_KEY="ci"
+            export QDRANT_URL="http://localhost:6333"
+            export KEYCLOAK_URL="http://localhost:8080"
+            export KEYCLOAK_REALM="ci"
+            export KEYCLOAK_CLIENT_ID="ci"
+            export KEYCLOAK_CLIENT_SECRET="ci"
+            PYTHONPATH=apps/api pytest apps/api/tests -q --disable-warnings --junitxml=apps/api/reports/pytest.xml | tee apps/api/reports/pytest.log
+          else
+            PYTHONPATH=apps/worker pytest apps/worker -q --disable-warnings --junitxml=apps/worker/reports/pytest.xml | tee apps/worker/reports/pytest.log
+          fi
+
+      - name: Upload backend artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.service }}-backend-reports
+          path: |
+            apps/${{ matrix.service }}/reports/**
+          if-no-files-found: warn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,101 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment to deploy
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+        required: true
+      ref:
+        description: Git ref to deploy
+        default: main
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+  packages: read
+
+jobs:
+  deploy:
+    name: Deploy to ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Abort when deployment secrets are missing
+        if: ${{ secrets.DEPLOY_HOST == '' || secrets.DEPLOY_USER == '' || secrets.DEPLOY_SSH_KEY == '' }}
+        run: |
+          echo 'Deployment secrets are not configured. Please define DEPLOY_HOST, DEPLOY_USER, and DEPLOY_SSH_KEY.' >&2
+          exit 1
+
+      - name: Prepare deployment manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p deployment
+          timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          cat <<JSON > deployment/manifest.json
+          {
+            "environment": "${{ github.event.inputs.environment }}",
+            "ref": "${{ github.event.inputs.ref }}",
+            "sha": "${{ github.sha }}",
+            "run_id": "${{ github.run_id }}",
+            "run_number": "${{ github.run_number }}",
+            "timestamp": "${timestamp}"
+          }
+          JSON
+
+      - name: Run remote deployment
+        if: ${{ secrets.DEPLOY_HOST != '' && secrets.DEPLOY_USER != '' && secrets.DEPLOY_SSH_KEY != '' }}
+        uses: appleboy/ssh-action@v0.1.10
+        env:
+          DEPLOY_PROJECT_DIR: ${{ secrets.DEPLOY_PROJECT_DIR }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
+          DEPLOY_REGISTRY: ${{ secrets.DEPLOY_REGISTRY }}
+          DEPLOY_REGISTRY_USERNAME: ${{ secrets.DEPLOY_REGISTRY_USERNAME }}
+          DEPLOY_REGISTRY_PASSWORD: ${{ secrets.DEPLOY_REGISTRY_PASSWORD }}
+          DEPLOY_IMAGE_TAG: ${{ github.sha }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: DEPLOY_PROJECT_DIR,DEPLOY_COMPOSE_FILE,DEPLOY_REGISTRY,DEPLOY_REGISTRY_USERNAME,DEPLOY_REGISTRY_PASSWORD,DEPLOY_IMAGE_TAG
+          script: |
+            set -euo pipefail
+            project_dir=${DEPLOY_PROJECT_DIR:-/opt/autohire}
+            compose_file=${DEPLOY_COMPOSE_FILE:-$project_dir/docker-compose.yml}
+            registry=${DEPLOY_REGISTRY:-ghcr.io}
+            if [ -n "${DEPLOY_REGISTRY_USERNAME:-}" ] && [ -n "${DEPLOY_REGISTRY_PASSWORD:-}" ]; then
+              echo "${DEPLOY_REGISTRY_PASSWORD}" | docker login "$registry" -u "${DEPLOY_REGISTRY_USERNAME}" --password-stdin
+            fi
+            if [ ! -f "$compose_file" ]; then
+              echo "Compose file $compose_file not found" >&2
+              exit 1
+            fi
+            export AUTOHIRE_IMAGE_TAG=${DEPLOY_IMAGE_TAG}
+            docker compose -f "$compose_file" pull || true
+            docker compose -f "$compose_file" up -d
+            docker compose -f "$compose_file" run --rm api alembic upgrade head
+            docker compose -f "$compose_file" run --rm worker celery -A app.worker call autohire.echo --args '["reindex"]'
+
+      - name: Upload deployment manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-manifest-${{ github.event.inputs.environment }}
+          path: deployment/manifest.json

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,98 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/**/Dockerfile'
+      - '.github/workflows/docker-build.yml'
+      - 'infrastructure/docker-compose.yml'
+  pull_request:
+    paths:
+      - 'apps/**/Dockerfile'
+      - '.github/workflows/docker-build.yml'
+      - 'infrastructure/docker-compose.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: candidate-portal
+            context: apps/candidate-portal
+            dockerfile: apps/candidate-portal/Dockerfile
+            image-suffix: candidate-portal
+          - name: employer-portal
+            context: apps/employer-portal
+            dockerfile: apps/employer-portal/Dockerfile
+            image-suffix: employer-portal
+          - name: admin-console
+            context: apps/admin-console
+            dockerfile: apps/admin-console/Dockerfile
+            image-suffix: admin-console
+          - name: api
+            context: apps/api
+            dockerfile: apps/api/Dockerfile
+            image-suffix: api
+          - name: worker
+            context: apps/worker
+            dockerfile: apps/worker/Dockerfile
+            image-suffix: worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ matrix.image-suffix }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ matrix.image-suffix }}:latest
+          cache-from: type=gha,scope=${{ matrix.image-suffix }}
+          cache-to: type=gha,scope=${{ matrix.image-suffix }},mode=max
+          provenance: false
+
+      - name: Publish build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${{ github.repository }}/${{ matrix.image-suffix }}"
+          echo "${image}@${{ steps.build.outputs.digest }}" | tee ${{ matrix.image-suffix }}-digest.txt
+
+      - name: Upload image digest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image-suffix }}-image-digest
+          path: ${{ matrix.image-suffix }}-digest.txt

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -26,4 +26,4 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
-    return Settings()  # type: ignore[arg-type]
+    return Settings()  # type: ignore[call-arg]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+plugins = pydantic.mypy
+show_error_codes = True
+warn_unused_configs = True


### PR DESCRIPTION
## Summary
- add a unified CI workflow that lint/type-checks/builds/tests each app and caches dependencies while uploading run artifacts
- introduce a Docker image build workflow that publishes cached multi-service images to GHCR and records digests
- provide a manual deploy workflow that authenticates over SSH to pull images, run migrations, and trigger worker reindexing, along with shared mypy settings

## Testing
- `mypy --config-file mypy.ini apps/api`
- `mypy --config-file mypy.ini apps/worker`
- `ruff check apps/api`
- `ruff check apps/worker`


------
https://chatgpt.com/codex/tasks/task_e_68d348ce7014832db027404fad659eb2